### PR TITLE
`LocalTime::from_micros` uses incorrect upper bound in assertion

### DIFF
--- a/edgedb-protocol/src/value.rs
+++ b/edgedb-protocol/src/value.rs
@@ -423,7 +423,7 @@ impl LocalDatetime {
 
 impl LocalTime {
     pub fn from_micros(micros: u64) -> LocalTime {
-        assert!(micros < 86400*1000_1000);
+        assert!(micros < 86400*1000_0000);
         return LocalTime { micros: micros as i64  }
     }
 }


### PR DESCRIPTION
`1000_1000` should be `1000_0000`

```
impl LocalTime {
    pub fn from_micros(micros: u64) -> LocalTime {
        assert!(micros < 86400 * 1000_1000);
```