### PR TITLE
Introduce a Reader to hide implementation details of deserialization

### DIFF
--- a/edgedb-client/src/reader.rs
+++ b/edgedb-client/src/reader.rs
@@ -80,14 +80,14 @@ impl<T> QueryableDecoder<T> {
 impl<T: Queryable> Decode for QueryableDecoder<T> {
     type Output = T;
     fn decode(&self, msg: Bytes) -> Result<T, DecodeError> {
-        Queryable::decode(&mut io::Cursor::new(msg))
+        Queryable::decode(edgedb_protocol::serialization::Reader::from_bytes(&msg))
     }
 }
 
 impl Decode for Arc<dyn Codec> {
     type Output = Value;
     fn decode(&self, msg: Bytes) -> Result<Self::Output, DecodeError> {
-        self.decode_value(&mut io::Cursor::new(msg))
+        self.decode_value(edgedb_protocol::serialization::Reader::from_bytes(&msg))
     }
 }
 

--- a/edgedb-derive/src/json.rs
+++ b/edgedb-derive/src/json.rs
@@ -21,11 +21,11 @@ pub fn derive(item: &syn::Item) -> syn::Result<TokenStream> {
     let expanded = quote! {
         impl #impl_generics ::edgedb_protocol::queryable::Queryable
             for #name #ty_generics {
-            fn decode_raw(buf: &mut ::std::io::Cursor<::bytes::Bytes>)
+            fn decode_raw(buf: &mut ::edgedb_protocol::serialization::Reader)
                 -> Result<Self, ::edgedb_protocol::errors::DecodeError>
             {
                 let json: ::edgedb_protocol::json::Json =
-                    ::edgedb_protocol::queryable::Queryable::decode(buf)?;
+                    ::edgedb_protocol::queryable::Queryable::decode_raw(buf)?;
                 Ok(::serde_json::from_str(json.as_ref())
                     .map_err(::edgedb_protocol::errors::decode_error)?)
             }

--- a/edgedb-derive/tests/json.rs
+++ b/edgedb-derive/tests/json.rs
@@ -1,6 +1,3 @@
-use std::io::Cursor;
-
-use bytes::Bytes;
 use edgedb_derive::Queryable;
 use edgedb_protocol::queryable::Queryable;
 use serde::Deserialize;
@@ -31,7 +28,7 @@ fn json_field() {
         \0\0\x0b\x86\0\0\0\x10\xf2\xe6F9\xd7\x04\x11\xea\
         \xa0<\x83\x9f\xd9\xbd\x88\x94\0\0\0\x19\
         \0\0\0\x02id\0\0\x0e\xda\0\0\0\x10\x01{\"field1\": 123}";
-    let res = ShapeWithJson::decode(&mut Cursor::new(Bytes::from_static(data)));
+    let res = ShapeWithJson::decode(edgedb_protocol::serialization::Reader::from_bytes(data));
     assert_eq!(res.unwrap(), ShapeWithJson {
         name: "id".into(),
         data: Data {
@@ -43,7 +40,7 @@ fn json_field() {
 #[test]
 fn json_row() {
     let data = b"\x01{\"field2\": 234}";
-    let res = JsonRow::decode(&mut Cursor::new(Bytes::from_static(data)));
+    let res = JsonRow::decode(edgedb_protocol::serialization::Reader::from_bytes(data));
     assert_eq!(res.unwrap(), JsonRow {
         field2: 234,
     });

--- a/edgedb-protocol/src/codec/raw.rs
+++ b/edgedb-protocol/src/codec/raw.rs
@@ -1,30 +1,37 @@
-use std::io::Cursor;
 use std::str;
+use std::mem::size_of;
+use std::time::SystemTime;
 
-use bytes::{Bytes, Buf};
+use bytes::Buf;
 use uuid::Uuid;
 
 use crate::errors::{self, DecodeError};
 use crate::json::Json;
 use snafu::{ResultExt, ensure};
+use crate::value::{Duration, LocalDate, LocalTime, LocalDatetime, BigInt, Decimal};
 
 
-pub trait RawCodec: Sized {
-    fn decode_raw(buf: &mut Cursor<Bytes>) -> Result<Self, DecodeError>;
+pub trait RawCodec<'t>: Sized {
+    fn decode_raw(buf: &mut &'t[u8]) -> Result<Self, DecodeError>;
 }
 
-impl RawCodec for String {
-    fn decode_raw(buf: &mut Cursor<Bytes>) -> Result<Self, DecodeError> {
-        let val = str::from_utf8(&buf.bytes())
-            .context(errors::InvalidUtf8)?
-            .to_owned();
+impl<'t> RawCodec<'t> for String {
+    fn decode_raw(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        <&str>::decode_raw(buf).map(|s|s.to_owned())
+    }
+}
+
+impl<'t> RawCodec<'t> for &'t str {
+    fn decode_raw(buf: &mut &'t [u8]) -> Result<Self, DecodeError> {
+        let val = str::from_utf8(*buf)
+            .context(errors::InvalidUtf8)?;
         buf.advance(buf.bytes().len());
         Ok(val)
     }
 }
 
-impl RawCodec for Json {
-    fn decode_raw(buf: &mut Cursor<Bytes>) -> Result<Self, DecodeError> {
+impl<'t> RawCodec<'t> for Json {
+    fn decode_raw(buf: &mut &[u8]) -> Result<Self, DecodeError> {
         ensure!(buf.remaining() >= 1, errors::Underflow);
         let format = buf.get_u8();
         ensure!(format == 1, errors::InvalidJsonFormat);
@@ -36,8 +43,8 @@ impl RawCodec for Json {
     }
 }
 
-impl RawCodec for Uuid {
-    fn decode_raw(buf: &mut Cursor<Bytes>) -> Result<Self, DecodeError> {
+impl<'t> RawCodec<'t> for Uuid {
+    fn decode_raw(buf: &mut &[u8]) -> Result<Self, DecodeError> {
         ensure!(buf.remaining() >= 16, errors::Underflow);
         let uuid = Uuid::from_slice(buf.bytes())
             .context(errors::InvalidUuid)?;
@@ -46,8 +53,8 @@ impl RawCodec for Uuid {
     }
 }
 
-impl RawCodec for bool {
-    fn decode_raw(buf: &mut Cursor<Bytes>) -> Result<Self, DecodeError> {
+impl<'t> RawCodec<'t> for bool {
+    fn decode_raw(buf: &mut &[u8]) -> Result<Self, DecodeError> {
         ensure!(buf.remaining() >= 1, errors::Underflow);
         let res = match buf.get_u8() {
             0x00 => false,
@@ -58,9 +65,148 @@ impl RawCodec for bool {
     }
 }
 
-impl RawCodec for i64 {
-    fn decode_raw(buf: &mut Cursor<Bytes>) -> Result<Self, DecodeError> {
-        ensure!(buf.remaining() >= 8, errors::Underflow);
+impl<'t> RawCodec<'t> for i16 {
+    fn decode_raw(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        ensure!(buf.remaining() >= size_of::<Self>(), errors::Underflow);
+        return Ok(buf.get_i16());
+    }
+}
+
+impl<'t> RawCodec<'t> for i32 {
+    fn decode_raw(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        ensure!(buf.remaining() >= size_of::<Self>(), errors::Underflow);
+        return Ok(buf.get_i32());
+    }
+}
+
+impl<'t> RawCodec<'t> for i64 {
+    fn decode_raw(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        ensure!(buf.remaining() >= size_of::<Self>(), errors::Underflow);
         return Ok(buf.get_i64());
+    }
+}
+
+impl<'t> RawCodec<'t> for f32 {
+    fn decode_raw(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        ensure!(buf.remaining() >= size_of::<Self>(), errors::Underflow);
+        return Ok(buf.get_f32());
+    }
+}
+
+impl<'t> RawCodec<'t> for f64 {
+    fn decode_raw(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        ensure!(buf.remaining() >= size_of::<Self>(), errors::Underflow);
+        return Ok(buf.get_f64());
+    }
+}
+
+impl<'t> RawCodec<'t> for &'t [u8] {
+    fn decode_raw(buf: &mut &'t [u8]) -> Result<Self, DecodeError> {
+        let val = *buf;
+        buf.advance(val.len());
+        Ok(val)
+    }
+}
+
+impl<'t> RawCodec<'t> for Vec<u8> {
+    fn decode_raw(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        <&[u8]>::decode_raw(buf).map(|s|s.to_owned())
+    }
+}
+
+impl<'t> RawCodec<'t> for Decimal {
+    fn decode_raw(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        ensure!(buf.remaining() >= 8, errors::Underflow);
+        let ndigits = buf.get_u16() as usize;
+        let weight = buf.get_i16();
+        let negative = match buf.get_u16() {
+            0x0000 => false,
+            0x4000 => true,
+            _ => errors::BadSign.fail()?,
+        };
+        let decimal_digits = buf.get_u16();
+        ensure!(buf.remaining() >= ndigits*2, errors::Underflow);
+        let mut digits = Vec::with_capacity(ndigits);
+        for _ in 0..ndigits {
+            digits.push(buf.get_u16());
+        }
+        Ok(Decimal {
+            negative, weight, decimal_digits, digits,
+        })
+    }
+}
+
+impl<'t> RawCodec<'t> for BigInt {
+    fn decode_raw(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        ensure!(buf.remaining() >= 8, errors::Underflow);
+        let ndigits = buf.get_u16() as usize;
+        let weight = buf.get_i16();
+        let negative = match buf.get_u16() {
+            0x0000 => false,
+            0x4000 => true,
+            _ => errors::BadSign.fail()?,
+        };
+        let decimal_digits = buf.get_u16();
+        ensure!(decimal_digits == 0, errors::NonZeroReservedBytes);
+        let mut digits = Vec::with_capacity(ndigits);
+        ensure!(buf.remaining() >= ndigits*2, errors::Underflow);
+        for _ in 0..ndigits {
+            digits.push(buf.get_u16());
+        }
+        Ok(BigInt {
+            negative, weight, digits,
+        })
+    }
+}
+
+impl<'t> RawCodec<'t> for Duration {
+    fn decode_raw(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        ensure!(buf.remaining() >= 16, errors::Underflow);
+        let micros = buf.get_i64();
+        let days = buf.get_u32();
+        let months = buf.get_u32();
+        ensure!(months == 0 && days == 0, errors::NonZeroReservedBytes);
+        Ok(Duration { micros })
+    }
+}
+
+impl<'t> RawCodec<'t> for SystemTime {
+    fn decode_raw(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        use std::time::{ Duration, UNIX_EPOCH };
+        let postgres_epoch :SystemTime = UNIX_EPOCH + Duration::from_secs(946684800);
+
+        ensure!(buf.remaining() >= 8, errors::Underflow);
+        let micros = buf.get_i64();
+        let val = if micros > 0 {
+            postgres_epoch + Duration::from_micros(micros as u64)
+        } else {
+            postgres_epoch - Duration::from_micros((-micros) as u64)
+        };
+        Ok(val)
+    }
+}
+
+impl<'t> RawCodec<'t> for LocalDatetime {
+    fn decode_raw(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        ensure!(buf.remaining() >= 8, errors::Underflow);
+        let micros = buf.get_i64();
+        Ok(LocalDatetime { micros })
+    }
+}
+
+impl<'t> RawCodec<'t> for LocalDate {
+    fn decode_raw(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        ensure!(buf.remaining() >= 4, errors::Underflow);
+        let days = buf.get_i32();
+        Ok(LocalDate { days })
+    }
+}
+
+impl<'t> RawCodec<'t> for LocalTime {
+    fn decode_raw(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        ensure!(buf.remaining() >= 8, errors::Underflow);
+        let micros = buf.get_i64();
+        ensure!(micros >= 0 && micros < 86400_000_000, errors::InvalidDate);
+        Ok(LocalTime { micros })
     }
 }

--- a/edgedb-protocol/src/lib.rs
+++ b/edgedb-protocol/src/lib.rs
@@ -2,6 +2,7 @@ mod encoding;
 mod common;
 mod bignum;
 mod time;
+pub mod serialization;
 pub mod client_message;
 pub mod server_message;
 pub mod errors;

--- a/edgedb-protocol/src/queryable.rs
+++ b/edgedb-protocol/src/queryable.rs
@@ -1,14 +1,11 @@
-use std::io::Cursor;
-
-use bytes::{Bytes, Buf};
-use snafu::{Snafu, ensure};
+use snafu::Snafu;
 use uuid::Uuid;
 
-use crate::errors::{self, DecodeError};
-use crate::codec::raw::RawCodec;
+use crate::errors::DecodeError;
 use crate::codec;
 use crate::descriptors::{Descriptor, TypePos};
 use crate::json::Json;
+use crate::serialization::Reader;
 
 
 #[derive(Snafu, Debug)]
@@ -31,12 +28,12 @@ pub struct DescriptorContext<'a> {
 }
 
 pub trait Queryable: Sized {
-    fn decode(buf: &mut Cursor<Bytes>) -> Result<Self, DecodeError> {
-        let result = Queryable::decode_raw(buf)?;
-        ensure!(buf.bytes().len() == 0, errors::ExtraData);
+    fn decode(mut buf: Reader) -> Result<Self, DecodeError> {
+        let result = Queryable::decode_raw(&mut buf)?;
+        buf.complete()?;
         Ok(result)
     }
-    fn decode_raw(buf: &mut Cursor<Bytes>) -> Result<Self, DecodeError>;
+    fn decode_raw(buf: &mut Reader) -> Result<Self, DecodeError>;
     fn check_descriptor(ctx: &DescriptorContext, type_pos: TypePos)
         -> Result<(), DescriptorMismatch>;
 }
@@ -81,8 +78,8 @@ impl DescriptorContext<'_> {
 }
 
 impl Queryable for String {
-    fn decode_raw(buf: &mut Cursor<Bytes>) -> Result<Self, DecodeError> {
-        RawCodec::decode_raw(buf)
+    fn decode_raw(buf: &mut Reader) -> Result<Self, DecodeError> {
+        buf.decode_raw()
     }
     fn check_descriptor(ctx: &DescriptorContext, type_pos: TypePos)
         -> Result<(), DescriptorMismatch>
@@ -103,8 +100,8 @@ impl Queryable for String {
 }
 
 impl Queryable for Json {
-    fn decode_raw(buf: &mut Cursor<Bytes>) -> Result<Self, DecodeError> {
-        RawCodec::decode_raw(buf)
+    fn decode_raw(buf: &mut Reader) -> Result<Self, DecodeError> {
+        buf.decode_raw()
     }
     fn check_descriptor(ctx: &DescriptorContext, type_pos: TypePos)
         -> Result<(), DescriptorMismatch>
@@ -125,8 +122,8 @@ impl Queryable for Json {
 }
 
 impl Queryable for i64 {
-    fn decode_raw(buf: &mut Cursor<Bytes>) -> Result<Self, DecodeError> {
-        RawCodec::decode_raw(buf)
+    fn decode_raw(buf: &mut Reader) -> Result<Self, DecodeError> {
+        buf.decode_raw()
     }
     fn check_descriptor(ctx: &DescriptorContext, type_pos: TypePos)
         -> Result<(), DescriptorMismatch>
@@ -147,8 +144,8 @@ impl Queryable for i64 {
 }
 
 impl Queryable for Uuid {
-    fn decode_raw(buf: &mut Cursor<Bytes>) -> Result<Self, DecodeError> {
-        RawCodec::decode_raw(buf)
+    fn decode_raw(buf: &mut Reader) -> Result<Self, DecodeError> {
+        buf.decode_raw()
     }
     fn check_descriptor(ctx: &DescriptorContext, type_pos: TypePos)
         -> Result<(), DescriptorMismatch>
@@ -169,8 +166,8 @@ impl Queryable for Uuid {
 }
 
 impl Queryable for bool {
-    fn decode_raw(buf: &mut Cursor<Bytes>) -> Result<Self, DecodeError> {
-        RawCodec::decode_raw(buf)
+    fn decode_raw(buf: &mut Reader) -> Result<Self, DecodeError> {
+        buf.decode_raw()
     }
     fn check_descriptor(ctx: &DescriptorContext, type_pos: TypePos)
         -> Result<(), DescriptorMismatch>

--- a/edgedb-protocol/src/serialization.rs
+++ b/edgedb-protocol/src/serialization.rs
@@ -1,0 +1,2 @@
+mod reader;
+pub use self::reader::Reader;

--- a/edgedb-protocol/src/serialization/reader.rs
+++ b/edgedb-protocol/src/serialization/reader.rs
@@ -1,0 +1,119 @@
+use bytes::Buf;
+use crate::codec::raw::RawCodec;
+use crate::{queryable::Queryable, errors::{self, DecodeError}};
+use snafu::ensure;
+
+pub struct Reader<'t>
+{
+    raw:Option<&'t [u8]>
+}
+
+impl<'t> std::fmt::Debug for Reader<'t> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Reader ")?;
+        match self.raw {
+            Some(raw) => { f.write_fmt(format_args!("{:x?}", raw))?; }
+            None => { f.write_str("errored")?; }
+        }
+        Ok(())
+    }
+}
+
+impl<'t> Reader<'t>
+{
+    fn error<E>(&mut self, e:E) -> E {
+        self.raw = None;
+        e
+    }
+
+    fn len(&self) -> usize {
+        self.raw_bytes().len()
+    }
+
+    pub fn complete(self) -> Result<(), DecodeError> {
+        ensure!(self.len() == 0, errors::ExtraData);
+        Ok(())
+    }
+
+    fn raw_bytes(&self) -> &'t [u8] {
+        &mut self.raw.expect("attempt to access an errored reader")
+    }
+
+    fn raw_mut(&mut self) -> &mut &'t [u8] {
+        self.raw.as_mut().expect("attempt to access an errored reader")
+    }
+
+    pub(crate) fn decode_raw<T:RawCodec<'t>>(&mut self) -> Result<T, DecodeError> {
+        T::decode_raw(self.raw_mut())
+    }
+
+    pub fn from_bytes(bytes:&'t [u8]) -> Self {
+        Reader { raw:Some(bytes) }
+    }
+
+    fn split(&mut self, position:usize) -> Result<Self, DecodeError> {
+        ensure!(self.len() >= position, self.error(errors::Underflow));
+        let buf = self.raw_mut();
+        let result = Reader::from_bytes(&buf[..position]);
+        buf.advance(position);
+        Ok(result)
+    }
+
+    pub fn read_object_element(&mut self) -> Result<Option<Self>, DecodeError> {
+        let buf = self.raw_mut();
+        ensure!(buf.remaining() >= 8, self.error(errors::Underflow));
+        let _reserved = buf.get_i32();
+        let len = buf.get_i32();
+        if len < 0 {
+            ensure!(len == -1, self.error(errors::InvalidMarker));
+            return Ok(None);
+        }
+        let len = len as usize;
+        Ok(Some(self.split(len)?))
+    }
+
+    pub(crate) fn read_tuple_element(&mut self) -> Result<Self, DecodeError> {
+        let buf = self.raw_mut();
+        ensure!(buf.remaining() >= 8, self.error(errors::Underflow));
+        let _reserved = buf.get_i32();
+        let len = buf.get_i32() as usize;
+        Ok(self.split(len)?)
+    }
+    
+    pub(crate) fn read_array_like_element(&mut self) -> Result<Self, DecodeError> {
+        let buf = self.raw_mut();
+        ensure!(buf.remaining() >= 4, self.error(errors::Underflow));
+        let len = buf.get_i32() as usize;
+        Ok(self.split(len)?)        
+    }
+    
+    pub fn read_tuple_like_header(&mut self) -> Result<usize, DecodeError> {
+        let buf = self.raw_mut();
+        ensure!(buf.remaining() >= 4, self.error(errors::Underflow));
+        Ok(buf.get_u32() as usize)
+    }
+
+    pub(crate) fn read_array_like_header(&mut self, ensure_shape: impl Fn(bool) -> Result<(), DecodeError>) -> Result<usize, DecodeError> {
+        let buf = self.raw_mut();
+        ensure!(buf.remaining() >= 12, self.error(errors::Underflow));
+        let ndims = buf.get_u32();
+        let _reserved0 = buf.get_u32();
+        let _reserved1 = buf.get_u32();
+        if ndims == 0 {
+            return Ok(0);
+        }
+        ensure_shape(ndims == 1)?;
+        ensure!(buf.remaining() >= 8, self.error(errors::Underflow));
+        let size = buf.get_u32() as usize;
+        let lower = buf.get_u32();
+        ensure_shape(lower == 1)?;
+        Ok(size)
+    }
+
+    pub fn get_object_element<T:Queryable>(&mut self) -> Result<T, DecodeError> {
+        let element = self.read_object_element()?;
+        // this doesn't handle the empty set case, but the original code didn't handle it either
+        ensure!(element.is_some(), self.error(errors::Underflow));
+        T::decode(element.unwrap())
+    }
+}

--- a/edgedb-protocol/tests/codecs.rs
+++ b/edgedb-protocol/tests/codecs.rs
@@ -1,10 +1,7 @@
-use std::io::{Cursor};
 use std::error::Error;
 use std::{i16, i32, i64};
 use std::sync::Arc;
 use std::time::UNIX_EPOCH;
-
-use bytes::{Bytes, Buf};
 
 use edgedb_protocol::codec::{build_codec, build_input_codec};
 use edgedb_protocol::codec::{Codec, ObjectShape};
@@ -37,10 +34,9 @@ macro_rules! encoding_eq {
 
 fn decode(codec: &Arc<dyn Codec>, data: &[u8]) -> Result<Value, Box<dyn Error>>
 {
-    let bytes = Bytes::copy_from_slice(data);
-    let mut cur = Cursor::new(bytes);
+    let mut cur = edgedb_protocol::serialization::Reader::from_bytes(data);
     let res = codec.decode(&mut cur)?;
-    assert!(cur.bytes() == b"");
+    cur.complete().expect("reader was not read to the end");
     Ok(res)
 }
 


### PR DESCRIPTION
As a first step towards encapsulating implementation details, I added a `Reader` struct which is consumed by `Queryable` instead `Cursor<Bytes>`.

* Introduced additional `RawCodec`s to move the low level serialization logic out of codec.rs
* use plain slices instead of Bytes
* Added a lifetime to `RawCodec`, so it can return slices into the original data (useful for `&str` and `&[u8]`)
* functions which assert that the complete data was parsed consume the reader
* Simplified the code generated by edgedb-derive, it now calls high level functions in Reader