### PR TITLE
Enable public access to edgeql-parser crate

### DIFF
--- a/edgedb-protocol/src/value.rs
+++ b/edgedb-protocol/src/value.rs
@@ -1,6 +1,6 @@
 use std::time::SystemTime;
 use crate::codec::{NamedTupleShape, ObjectShape, EnumValue};
-use crate::model::{ BigInt, Decimal, LocalDatetime, LocalDate, LocalTime, Duration, Uuid };
+pub use crate::model::{ BigInt, Decimal, LocalDatetime, LocalDate, LocalTime, Duration, Uuid };
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Value {

--- a/edgedb-protocol/src/value.rs
+++ b/edgedb-protocol/src/value.rs
@@ -1,5 +1,5 @@
-use std::time::SystemTime;
-use crate::codec::{NamedTupleShape, ObjectShape, EnumValue};
+pub use std::time::SystemTime;
+pub use crate::codec::{NamedTupleShape, ObjectShape, EnumValue};
 pub use crate::model::{ BigInt, Decimal, LocalDatetime, LocalDate, LocalTime, Duration, Uuid };
 
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
Unless there are builder macros requiring private access to the `BigInt` and `Decimal` types, I believe they can be made public to enable 3rd-party access to [edgeql-parser](https://github.com/edgedb/edgedb/tree/master/edb/edgeql-parser) and [edgeql-rust](https://github.com/edgedb/edgedb/tree/master/edb/edgeql-parser).

This PR is motivated by https://github.com/edgedb/edgedb-rust/issues/52 .