### PR TITLE
Verify hostname and allow custom verifier

### DIFF
--- a/edgedb-client/src/builder.rs
+++ b/edgedb-client/src/builder.rs
@@ -199,6 +199,23 @@ impl Builder {
             verify_hostname: None,
         }
     }
+    pub fn as_credentials(&self) -> anyhow::Result<Credentials> {
+        let (host, port) = match &self.addr {
+            Addr(AddrImpl::Tcp(host, port)) => (host, port),
+            Addr(AddrImpl::Unix(_)) => {
+                anyhow::bail!("Cannot generate credentials with UNIX socket.");
+            }
+        };
+        Ok(Credentials {
+            host: Some(host.into()),
+            port: port.clone(),
+            user: self.user.clone(),
+            password: self.password.clone(),
+            database: Some(self.database.clone()),
+            tls_cert_data: None,
+            tls_verify_hostname: self.verify_hostname,
+        })
+    }
     pub fn get_addr(&self) -> &Addr {
         &self.addr
     }

--- a/edgedb-client/src/lib.rs
+++ b/edgedb-client/src/lib.rs
@@ -8,3 +8,4 @@ pub mod reader;
 pub mod server_params;
 
 pub use builder::Builder;
+pub use tls::verify_server_cert;


### PR DESCRIPTION
* Add `Builder.as_credentials()`
* Add `Builder.connect_with_cert_verifier()` and `verify_server_cert()`
* Store and export the cert in PEM format.
* Add `Addr.get_tcp_addr()` and `Addr.get_unix_addr()`