### PR TITLE
Verify hostname and support `edgedb authenticate`

### DIFF
--- a/edgedb-client/src/lib.rs
+++ b/edgedb-client/src/lib.rs
@@ -8,3 +8,4 @@ pub mod reader;
 pub mod server_params;
 
 pub use builder::Builder;
+pub use tls::verify_server_cert;


### PR DESCRIPTION
* Add `Builder.as_credentials()`
* Add `Builder.connect_with_cert_verifier()` and `verify_server_cert()`
* Store and export the cert in PEM format.
* Add `Addr.get_tcp_addr()` and `Addr.get_unix_addr()`