### PR TITLE
Connect to localhost by default instead 127.0.0.1

### DIFF
--- a/edgedb-client/src/builder.rs
+++ b/edgedb-client/src/builder.rs
@@ -164,7 +164,7 @@ impl Builder {
         }
         Ok(Builder {
             addr: Addr(AddrImpl::Tcp(
-                credentials.host.clone().unwrap_or_else(|| "127.0.0.1".into()),
+                credentials.host.clone().unwrap_or_else(|| "localhost".into()),
                 credentials.port)),
             user: credentials.user.clone(),
             password: credentials.password.clone(),


### PR DESCRIPTION
Plays nicer with TLS

Looks like works well with dual ipv4/ipv6 localhost.