### PR TITLE
Initial support of protocol 0.12 and static arguments support

### DIFF
--- a/edgedb-protocol/src/common.rs
+++ b/edgedb-protocol/src/common.rs
@@ -24,3 +24,16 @@ impl std::convert::TryFrom<u8> for Cardinality {
     }
 }
 
+impl Cardinality {
+    pub fn is_optional(&self) -> bool {
+        use Cardinality::*;
+        match self {
+            NoResult => true,
+            AtMostOne => true,
+            One => false,
+            Many => true,
+            AtLeastOne => false,
+        }
+    }
+}
+

--- a/edgedb-protocol/src/descriptors.rs
+++ b/edgedb-protocol/src/descriptors.rs
@@ -163,6 +163,9 @@ impl InputTypedesc {
             _ => false,
         }
     }
+    pub fn proto(&self) -> &ProtocolVersion {
+        &self.proto
+    }
 }
 
 impl Descriptor {

--- a/edgedb-protocol/src/descriptors.rs
+++ b/edgedb-protocol/src/descriptors.rs
@@ -43,7 +43,7 @@ pub struct InputTypedesc {
     pub(crate) array: Vec<Descriptor>,
     #[allow(dead_code)] // TODO
     pub(crate) root_id: Uuid,
-    pub(crate) root_pos: TypePos,
+    pub(crate) root_pos: Option<TypePos>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -144,13 +144,13 @@ impl InputTypedesc {
         &self.array
     }
     pub fn build_codec(&self) -> Result<Arc<dyn Codec>, CodecError> {
-        build_codec(Some(self.root_pos()), self.descriptors())
+        build_codec(self.root_pos(), self.descriptors())
     }
-    pub fn root_pos(&self) -> TypePos {
+    pub fn root(&self) -> Option<&Descriptor> {
+        self.root_pos.and_then(|pos| self.array.get(pos.0 as usize))
+    }
+    pub fn root_pos(&self) -> Option<TypePos> {
         self.root_pos
-    }
-    pub fn root(&self) -> &Descriptor {
-        &self.array[self.root_pos.0 as usize]
     }
     pub fn get(&self, type_pos: TypePos) -> Result<&Descriptor, CodecError> {
         self.array.get(type_pos.0 as usize)
@@ -158,7 +158,7 @@ impl InputTypedesc {
     }
     pub fn is_empty_tuple(&self) -> bool {
         match self.root() {
-            Descriptor::Tuple(t)
+            Some(Descriptor::Tuple(t))
               => t.id == Uuid::from_u128(0xFF) && t.element_types.is_empty(),
             _ => false,
         }

--- a/edgedb-protocol/src/features.rs
+++ b/edgedb-protocol/src/features.rs
@@ -8,7 +8,7 @@ impl ProtocolVersion {
     pub fn current() -> ProtocolVersion {
         ProtocolVersion {
             major_ver: 0,
-            minor_ver: 11,
+            minor_ver: 12,
         }
     }
     pub fn new(major_ver: u16, minor_ver: u16) -> ProtocolVersion {
@@ -27,6 +27,11 @@ impl ProtocolVersion {
         self.version_tuple() <= (0, 8)
     }
     pub fn is_at_least(&self, major_ver: u16, minor_ver: u16) -> bool {
-        self.major_ver >= major_ver && self.minor_ver >= minor_ver
+        self.major_ver > major_ver ||
+        self.major_ver == major_ver && self.minor_ver >= minor_ver
+    }
+    pub fn is_at_most(&self, major_ver: u16, minor_ver: u16) -> bool {
+        self.major_ver < major_ver ||
+        self.major_ver == major_ver && self.minor_ver <= minor_ver
     }
 }

--- a/edgedb-protocol/src/query_arg.rs
+++ b/edgedb-protocol/src/query_arg.rs
@@ -1,23 +1,37 @@
+use std::convert::TryFrom;
 use std::sync::Arc;
 
 use bytes::{BytesMut, BufMut};
+use snafu::OptionExt;
 
 use edgedb_errors::{Error, ErrorKind};
-use edgedb_errors::{ClientEncodingError, ProtocolError};
+use edgedb_errors::{ClientEncodingError, ProtocolError, DescriptorMismatch};
 
 use crate::codec::{Codec, build_codec};
 use crate::descriptors::Descriptor;
 use crate::descriptors::TypePos;
+use crate::errors;
 use crate::features::ProtocolVersion;
 use crate::value::Value;
 
 
 pub struct Encoder<'a> {
-    ctx: &'a DescriptorContext<'a>,
-    buf: &'a mut BytesMut,
+    pub(crate) ctx: &'a DescriptorContext<'a>,
+    pub(crate) buf: &'a mut BytesMut,
 }
 
 pub trait QueryArg: Sized {
+    fn encode_slot(&self, encoder: &mut Encoder)
+        -> Result<(), Error>;
+    fn check_descriptor(ctx: &DescriptorContext, pos: TypePos)
+        -> Result<(), Error>;
+}
+
+pub trait ScalarArg: Sized {
+    fn encode(&self, encoder: &mut Encoder)
+        -> Result<(), Error>;
+    fn check_descriptor(ctx: &DescriptorContext, pos: TypePos)
+        -> Result<(), Error>;
 }
 
 pub trait QueryArgs: Sized {
@@ -28,7 +42,7 @@ pub trait QueryArgs: Sized {
 pub struct DescriptorContext<'a> {
     #[allow(dead_code)]
     pub(crate) proto: &'a ProtocolVersion,
-    pub(crate) root_pos: TypePos,
+    pub(crate) root_pos: Option<TypePos>,
     pub(crate) descriptors: &'a [Descriptor],
 }
 
@@ -41,10 +55,44 @@ impl<'a> Encoder<'a> {
 }
 
 impl DescriptorContext<'_> {
+    pub fn get(&self, type_pos: TypePos)
+        -> Result<&Descriptor, Error>
+    {
+        self.descriptors.get(type_pos.0 as usize)
+            .ok_or_else(|| ProtocolError::with_message(
+                "invalid type descriptor"))
+    }
     pub fn build_codec(&self) -> Result<Arc<dyn Codec>, Error> {
-        build_codec(Some(self.root_pos), self.descriptors)
+        build_codec(self.root_pos, self.descriptors)
         .map_err(|e| ProtocolError::with_source(e)
             .context("error decoding input codec"))
+    }
+    pub fn wrong_type(&self, descriptor: &Descriptor, expected: &str) -> Error
+    {
+        DescriptorMismatch::with_message(format!(
+            "unexpected type {:?}, expected {}",
+            descriptor, expected))
+    }
+    pub fn field_number(&self, expected: usize, unexpected: usize)
+        -> Error
+    {
+        DescriptorMismatch::with_message(format!(
+            "expected {} fields, got {}",
+            expected, unexpected))
+    }
+}
+
+impl<T: ScalarArg> ScalarArg for &T {
+    fn encode(&self, encoder: &mut Encoder)
+        -> Result<(), Error>
+    {
+        (*self).encode(encoder)
+    }
+
+    fn check_descriptor(ctx: &DescriptorContext, pos: TypePos)
+        -> Result<(), Error>
+    {
+        T::check_descriptor(ctx, pos)
     }
 }
 
@@ -52,6 +100,10 @@ impl QueryArgs for () {
     fn encode(&self, enc: &mut Encoder)
         -> Result<(), Error>
     {
+        if enc.ctx.root_pos.is_some() {
+            return Err(DescriptorMismatch::with_message(
+                "query arguments expected"));
+        }
         enc.buf.reserve(4);
         enc.buf.put_u32(0);
         Ok(())
@@ -67,3 +119,97 @@ impl QueryArgs for Value {
             .map_err(ClientEncodingError::with_source)
     }
 }
+
+impl<T: ScalarArg> QueryArg for T {
+    fn encode_slot(&self, enc: &mut Encoder) -> Result<(), Error> {
+        let pos = enc.buf.len();
+        ScalarArg::encode(self, enc)?;
+        let len = enc.buf.len()-pos-4;
+        enc.buf[pos..pos+4].copy_from_slice(&i32::try_from(len)
+                .ok().context(errors::ElementTooLong)
+                .map_err(ClientEncodingError::with_source)?
+                .to_be_bytes());
+        Ok(())
+    }
+    fn check_descriptor(ctx: &DescriptorContext, pos: TypePos)
+        -> Result<(), Error>
+    {
+        T::check_descriptor(ctx, pos)
+    }
+}
+
+impl<T: ScalarArg> QueryArg for Option<T> {
+    fn encode_slot(&self, enc: &mut Encoder) -> Result<(), Error> {
+        if let Some(val) = self {
+            QueryArg::encode_slot(val, enc)
+        } else {
+            enc.buf.put_i32(-1);
+            Ok(())
+        }
+    }
+    fn check_descriptor(ctx: &DescriptorContext, pos: TypePos)
+        -> Result<(), Error>
+    {
+        T::check_descriptor(ctx, pos)
+    }
+}
+
+macro_rules! implement_tuple {
+    ( $count:expr, $($name:ident,)+ ) => {
+        impl<$($name:QueryArg),+> QueryArgs for ($($name,)+) {
+            fn encode(&self, enc: &mut Encoder)
+                -> Result<(), Error>
+            {
+                #![allow(non_snake_case)]
+                let root_pos = enc.ctx.root_pos
+                    .ok_or_else(|| DescriptorMismatch::with_message(
+                        "provided {} positional arguments, \
+                         but no arguments expected by the server"))?;
+                let desc = enc.ctx.get(root_pos)?;
+                match desc {
+                    Descriptor::ObjectShape(desc) => {
+                        if desc.elements.len() != $count {
+                            return Err(enc.ctx.field_number(
+                                $count, desc.elements.len()));
+                        }
+                        let mut els = desc.elements.iter().enumerate();
+                        $(
+                            let (idx, el) = els.next().unwrap();
+                            if el.name.parse() != Ok(idx) {
+                                return Err(DescriptorMismatch::with_message(
+                                    format!("expected positional arguments, \
+                                             got {} instead of {}",
+                                             el.name, idx)));
+                            }
+                            $name::check_descriptor(enc.ctx, el.type_pos)?;
+                        )+
+                    }
+                    _ => return Err(enc.ctx.wrong_type(desc, "tuple"))
+                }
+
+                enc.buf.reserve(4 + 8*$count);
+                enc.buf.put_u32($count);
+                let ($(ref $name,)+) = self;
+                $(
+                    enc.buf.reserve(8);
+                    enc.buf.put_u32(0);
+                    QueryArg::encode_slot($name, enc)?;
+                )*
+                Ok(())
+            }
+        }
+    }
+}
+
+implement_tuple!{1, T0, }
+implement_tuple!{2, T0, T1, }
+implement_tuple!{3, T0, T1, T2, }
+implement_tuple!{4, T0, T1, T2, T3, }
+implement_tuple!{5, T0, T1, T2, T3, T4, }
+implement_tuple!{6, T0, T1, T2, T3, T4, T5, }
+implement_tuple!{7, T0, T1, T2, T3, T4, T5, T6, }
+implement_tuple!{8, T0, T1, T2, T3, T4, T5, T6, T7, }
+implement_tuple!{9, T0, T1, T2, T3, T4, T5, T6, T7, T8, }
+implement_tuple!{10, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, }
+implement_tuple!{11, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, }
+implement_tuple!{12, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, }

--- a/edgedb-protocol/src/serialization/decode/queryable.rs
+++ b/edgedb-protocol/src/serialization/decode/queryable.rs
@@ -1,3 +1,3 @@
-mod scalars;
-mod tuples;
-mod collections;
+pub(crate) mod scalars;
+pub(crate) mod tuples;
+pub(crate) mod collections;

--- a/edgedb-protocol/src/server_message.rs
+++ b/edgedb-protocol/src/server_message.rs
@@ -209,11 +209,15 @@ impl CommandDataDescription {
             }
         }
         let root_id = self.input_typedesc_id.clone();
-        let idx = descriptors.iter().position(|x| *x.id() == root_id)
-            .context(errors::UuidNotFound { uuid: root_id })?;
-        let pos = idx.try_into().ok()
-            .context(errors::TooManyDescriptors { index: idx })?;
-        let root_pos = TypePos(pos);
+        let root_pos = if root_id == Uuid::from_u128(0) {
+            None
+        } else {
+            let idx = descriptors.iter().position(|x| *x.id() == root_id)
+                .context(errors::UuidNotFound { uuid: root_id })?;
+            let pos = idx.try_into().ok()
+                .context(errors::TooManyDescriptors { index: idx })?;
+            Some(TypePos(pos))
+        };
         Ok(InputTypedesc {
             array: descriptors,
             proto: self.proto.clone(),


### PR DESCRIPTION
This implements new protocol for describing/sending query arguments.

This only implements `String` so far for statically types arguments (others will be added later).

There is a bug, which we probably will never fix: since protocol previous accepted named tuple or tuple as arguments and now uses object. For queries with dynamic arguments (`edgedb_protocol::value::Value`) user has to use specific type `Value::Object` or `Value::Tuple` or `Value::NamedTuple` depending on the protocol version. I think we never need to fix this as 0.11 will be deprecated when Rust bindings are released. And CLI will handle version handling by itself.