### PR TITLE
proto 0.12: empty tuple args have zero-length data

### DIFF
--- a/edgedb-protocol/src/query_arg.rs
+++ b/edgedb-protocol/src/query_arg.rs
@@ -117,8 +117,10 @@ impl QueryArgs for () {
                     "query arguments expected"));
             }
         }
-        enc.buf.reserve(4);
-        enc.buf.put_u32(0);
+        if enc.ctx.proto.is_at_most(0, 11) {
+            enc.buf.reserve(4);
+            enc.buf.put_u32(0);
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Depends on https://github.com/edgedb/edgedb/pull/2894