### PR TITLE
Add `Builder::from_env`

### DIFF
--- a/edgedb-client/Cargo.toml
+++ b/edgedb-client/Cargo.toml
@@ -15,6 +15,7 @@ scram = "0.5.0"
 typemap = "0.3.3"
 serde = "1.0"
 serde_json = "1.0"
+sha1 = {version="0.6.0", features=["std"]}
 log = "0.4.8"
 rand = "0.8"
 url = "2.1.1"
@@ -26,3 +27,8 @@ rustls = "0.19.1"
 rustls-native-certs = "0.5.0"
 webpki = "0.21.4"
 webpki-roots = "0.21"
+dirs = "3.0.0"
+
+[features]
+default = []
+admin_socket = []

--- a/edgedb-errors/src/kinds.rs
+++ b/edgedb-errors/src/kinds.rs
@@ -149,6 +149,7 @@ define_errors![
     (struct PasswordRequired, 0x0701FF00u32, 0x00000000),
     (struct ClientInconsistentError, 0xFFFF0000u32, 0x00000000),
     (struct ClientEncodingError, 0xFFFE0000u32, 0x00000000),
+    (struct ClientNoCredentialsError, 0xFF0101FFu32, 0x00000000),
     (struct ClientConnectionEosError, 0xFF01FF00u32, 0x00000000),
     (struct NoResultExpected, 0xFF02FF00u32, 0x00000000),
     (struct DescriptorMismatch, 0xFF02FE00u32, 0x00000000),


### PR DESCRIPTION
This supports new conventions for connection parameters: https://github.com/edgedb/edgedb/discussions/2922
And new `EDGEDB_INSECURE_DEV_MODE` env variable: https://github.com/edgedb/edgedb/discussions/2897