### PR TITLE
Allow instance link to an IP address

### DIFF
--- a/edgedb-client/Cargo.toml
+++ b/edgedb-client/Cargo.toml
@@ -32,3 +32,4 @@ dirs = "3.0.0"
 [features]
 default = []
 admin_socket = []
+unstable = []  # features for CLI


### PR DESCRIPTION
This includes:
* hiding `connect_with_cert_verifier` under cargo feature
* masquarading ip address hostname until rustls/webpki issue is fixed

Partialy fixes edgedb/edgedb#2903