### PR TITLE
Bump crate versions to 0.2.0

### DIFF
--- a/edgedb-client/Cargo.toml
+++ b/edgedb-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "edgedb-client"
 license = "MIT/Apache-2.0"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["MagicStack Inc. <hello@magic.io>"]
 edition = "2018"
 description = """
@@ -9,9 +9,9 @@ description = """
 """
 
 [dependencies]
-edgedb-protocol = {path = "../edgedb-protocol", version="0.1.0"}
+edgedb-protocol = {path = "../edgedb-protocol", version="0.2.0"}
 edgedb-errors = {path = "../edgedb-errors", version="0.1.0"}
-edgedb-derive = {path = "../edgedb-derive", version="0.1.0", optional=true}
+edgedb-derive = {path = "../edgedb-derive", version="0.2.0", optional=true}
 snafu = {version="0.6.0", features=["backtraces"]}
 async-std = {version="1.10", features=[
     "unstable", # Condvar


### PR DESCRIPTION
The issue is that reserved packages took version 0.1.0 (instead of 0.0.0)