### PR TITLE
Bump versions of more crates to 0.2.0

### DIFF
--- a/edgedb-derive/Cargo.toml
+++ b/edgedb-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "edgedb-derive"
 license = "MIT/Apache-2.0"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["MagicStack Inc. <hello@magic.io>"]
 edition = "2018"
 description = """

--- a/edgedb-protocol/Cargo.toml
+++ b/edgedb-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "edgedb-protocol"
 license = "MIT/Apache-2.0"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["MagicStack Inc. <hello@magic.io>"]
 edition = "2018"
 description = """


### PR DESCRIPTION
The issue is that reserved packages took version 0.1.0 (instead of 0.0.0)