### PR TITLE
macro usage ergonomics

### DIFF
--- a/edgedb-client/src/lib.rs
+++ b/edgedb-client/src/lib.rs
@@ -41,6 +41,11 @@ pub use edgedb_protocol::model;
 pub use edgedb_protocol::query_arg::{QueryArg, QueryArgs};
 pub use edgedb_protocol::{QueryResult};
 
+// this is needed in order to avoid requiring user crate to explicitly
+// depend on `edgedb_protocol` in their `Cargo.toml`
+#[cfg(feature = "derive")]
+pub use ::edgedb_protocol as protocol;
+
 #[cfg(feature="derive")]
 pub use edgedb_derive::Queryable;
 

--- a/edgedb-client/src/lib.rs
+++ b/edgedb-client/src/lib.rs
@@ -44,6 +44,7 @@ pub use edgedb_protocol::{QueryResult};
 // this is needed in order to avoid requiring user crate to explicitly
 // depend on `edgedb_protocol` in their `Cargo.toml`
 #[cfg(feature = "derive")]
+#[doc(hidden)]
 pub use ::edgedb_protocol as protocol;
 
 #[cfg(feature="derive")]

--- a/edgedb-derive/src/json.rs
+++ b/edgedb-derive/src/json.rs
@@ -19,23 +19,23 @@ pub fn derive(item: &syn::Item) -> syn::Result<TokenStream> {
         }
     };
     let expanded = quote! {
-        impl #impl_generics ::edgedb_protocol::queryable::Queryable
+        impl #impl_generics ::edgedb_client::protocol::queryable::Queryable
             for #name #ty_generics {
-            fn decode(decoder: &::edgedb_protocol::queryable::Decoder, buf: &[u8])
-                -> Result<Self, ::edgedb_protocol::errors::DecodeError>
+            fn decode(decoder: &::edgedb_client::protocol::queryable::Decoder, buf: &[u8])
+                -> Result<Self, ::edgedb_client::protocol::errors::DecodeError>
             {
-                let json: ::edgedb_protocol::model::Json =
-                    ::edgedb_protocol::queryable::Queryable::decode(decoder, buf)?;
+                let json: ::edgedb_client::protocol::model::Json =
+                    ::edgedb_client::protocol::queryable::Queryable::decode(decoder, buf)?;
                 Ok(::serde_json::from_str(json.as_ref())
-                    .map_err(::edgedb_protocol::errors::decode_error)?)
+                    .map_err(::edgedb_client::protocol::errors::decode_error)?)
             }
             fn check_descriptor(
-                ctx: &::edgedb_protocol::queryable::DescriptorContext,
-                type_pos: ::edgedb_protocol::descriptors::TypePos)
-                -> Result<(), ::edgedb_protocol::queryable::DescriptorMismatch>
+                ctx: &::edgedb_client::protocol::queryable::DescriptorContext,
+                type_pos: ::edgedb_client::protocol::descriptors::TypePos)
+                -> Result<(), ::edgedb_client::protocol::queryable::DescriptorMismatch>
             {
-                <::edgedb_protocol::model::Json as
-                    ::edgedb_protocol::queryable::Queryable>
+                <::edgedb_client::protocol::model::Json as
+                    ::edgedb_client::protocol::queryable::Queryable>
                     ::check_descriptor(ctx, type_pos)
             }
         }

--- a/edgedb-derive/src/shape.rs
+++ b/edgedb-derive/src/shape.rs
@@ -86,17 +86,17 @@ pub fn derive_struct(s: &syn::ItemStruct) -> syn::Result<TokenStream> {
         let ref fieldname = field.name;
         if field.attrs.json {
             quote!{
-                let #fieldname: ::edgedb_protocol::model::Json =
-                    <::edgedb_protocol::model::Json as
-                        ::edgedb_protocol::queryable::Queryable>
+                let #fieldname: ::edgedb_client::protocol::model::Json =
+                    <::edgedb_client::protocol::model::Json as
+                        ::edgedb_client::protocol::queryable::Queryable>
                     ::decode_optional(decoder, elements.read()?)?;
                 let #fieldname = ::serde_json::from_str(#fieldname.as_ref())
-                    .map_err(::edgedb_protocol::errors::decode_error)?;
+                    .map_err(::edgedb_client::protocol::errors::decode_error)?;
             }
         } else {
             quote!{
                 let #fieldname =
-                    ::edgedb_protocol::queryable::Queryable
+                    ::edgedb_client::protocol::queryable::Queryable
                     ::decode_optional(decoder, elements.read()?)?;
             }
         }
@@ -113,13 +113,13 @@ pub fn derive_struct(s: &syn::ItemStruct) -> syn::Result<TokenStream> {
         let ref fieldtype = field.ty;
         if field.attrs.json {
             result.extend(quote!{
-                <::edgedb_protocol::model::Json as
-                    ::edgedb_protocol::queryable::Queryable>
+                <::edgedb_client::protocol::model::Json as
+                    ::edgedb_client::protocol::queryable::Queryable>
                     ::check_descriptor(ctx, el.type_pos)?;
             });
         } else {
             result.extend(quote!{
-                <#fieldtype as ::edgedb_protocol::queryable::Queryable>
+                <#fieldtype as ::edgedb_client::protocol::queryable::Queryable>
                     ::check_descriptor(ctx, el.type_pos)?;
             });
         }
@@ -127,16 +127,16 @@ pub fn derive_struct(s: &syn::ItemStruct) -> syn::Result<TokenStream> {
     }).collect::<TokenStream>();
 
     let expanded = quote! {
-        impl #impl_generics ::edgedb_protocol::queryable::Queryable
+        impl #impl_generics ::edgedb_client::protocol::queryable::Queryable
             for #name #ty_generics {
-            fn decode(decoder: &::edgedb_protocol::queryable::Decoder, buf: &[u8])
-                -> Result<Self, ::edgedb_protocol::errors::DecodeError>
+            fn decode(decoder: &::edgedb_client::protocol::queryable::Decoder, buf: &[u8])
+                -> Result<Self, ::edgedb_client::protocol::errors::DecodeError>
             {
                 let nfields = #base_fields
                     + if decoder.has_implicit_tid { 1 } else { 0 }
                     + if decoder.has_implicit_tname { 1 } else { 0 };
                 let mut elements =
-                    ::edgedb_protocol::serialization::decode::DecodeTupleLike
+                    ::edgedb_client::protocol::serialization::decode::DecodeTupleLike
                     ::new_object(buf, nfields)?;
 
                 #type_id_block
@@ -150,11 +150,11 @@ pub fn derive_struct(s: &syn::ItemStruct) -> syn::Result<TokenStream> {
                 })
             }
             fn check_descriptor(
-                ctx: &::edgedb_protocol::queryable::DescriptorContext,
-                type_pos: ::edgedb_protocol::descriptors::TypePos)
-                -> Result<(), ::edgedb_protocol::queryable::DescriptorMismatch>
+                ctx: &::edgedb_client::protocol::queryable::DescriptorContext,
+                type_pos: ::edgedb_client::protocol::descriptors::TypePos)
+                -> Result<(), ::edgedb_client::protocol::queryable::DescriptorMismatch>
             {
-                use ::edgedb_protocol::descriptors::Descriptor::ObjectShape;
+                use ::edgedb_client::protocol::descriptors::Descriptor::ObjectShape;
                 let desc = ctx.get(type_pos)?;
                 let shape = match desc {
                     ObjectShape(shape) => shape,


### PR DESCRIPTION
## Summary of changes

- More ergonomic macro usage, see  [Proc macros - using third party crate](https://users.rust-lang.org/t/proc-macros-using-third-party-crate/42465/4) for a detailed write-up
  - Eliminates the need for users to explicitly add `edgedb_protocol` dependency in their `Cargo.toml`
  - Aliases `edgedb_protocol` as `protocol` to eliminate redundancy in path naming in `edgedb_derive` crate

**supersedes** PR #122

P.S. I ran the available tests again, all passed.