### PR TITLE
Update Client::transaction docs with ressources that show how to return custom error types

### DIFF
--- a/edgedb-tokio/src/client.rs
+++ b/edgedb-tokio/src/client.rs
@@ -332,6 +332,12 @@ impl Client {
     /// but also executing the whole function, so the transaction code must be
     /// prepared to be idempotent.
     ///
+    /// # Returning custom errors
+    ///
+    /// See [this example](https://github.com/edgedb/edgedb-rust/blob/master/edgedb-tokio/examples/transaction_errors.rs)
+    /// and [the documentation of the `edgedb_errors` crate](https://docs.rs/edgedb-errors/latest/edgedb_errors/)
+    /// for how to return custom error types.
+    ///
     /// # Panics
     ///
     /// Function panics when transaction object passed to the closure is not


### PR DESCRIPTION
This adds two links to the documentation of `Client::transaction` that show how to return custom error types from transactions ([which was pretty unclear to me](https://github.com/edgedb/edgedb-rust/issues/168)).

Feel free to change however you like (English isn't my native language).