### PR TITLE
Fix handling of implicit id column in derive

### DIFF
--- a/edgedb-derive/src/shape.rs
+++ b/edgedb-derive/src/shape.rs
@@ -35,10 +35,7 @@ pub fn derive_struct(s: &syn::ItemStruct) -> syn::Result<TokenStream> {
     };
     let fieldname = fields.iter()
         .map(|f| f.name.clone()).collect::<Vec<_>>();
-    let has_id = fieldname.iter()
-        .find(|x| x.to_string() == "id").is_some();
-    let base_fields = fields.len()
-        + if has_id { 0 } else { 1 };
+    let base_fields = fields.len();
     let type_id_block = Some(quote! {
         if decoder.has_implicit_tid {
             elements.skip_element()?;
@@ -49,13 +46,11 @@ pub fn derive_struct(s: &syn::ItemStruct) -> syn::Result<TokenStream> {
             elements.skip_element()?;
         }
     });
-    let id_block = if has_id {
-        None
-    } else {
-        Some(quote! {
+    let id_block = Some(quote! {
+        if decoder.has_implicit_id {
             elements.skip_element()?;
-        })
-    };
+        }
+    });
     let type_id_check = Some(quote! {
         if ctx.has_implicit_tid {
             if(!shape.elements[idx].flag_implicit) {
@@ -67,21 +62,19 @@ pub fn derive_struct(s: &syn::ItemStruct) -> syn::Result<TokenStream> {
     let type_name_check = Some(quote! {
         if ctx.has_implicit_tname {
             if(!shape.elements[idx].flag_implicit) {
-                return Err(ctx.expected("implicit __tid__"));
+                return Err(ctx.expected("implicit __tname__"));
             }
             idx += 1;
         }
     });
-    let id_check = if has_id {
-        None
-    } else {
-        Some(quote! {
+    let id_check = Some(quote! {
+        if ctx.has_implicit_id {
             if(!shape.elements[idx].flag_implicit) {
                 return Err(ctx.expected("implicit id"));
             }
             idx += 1;
-        })
-    };
+        }
+    });
     let field_decoders = fields.iter().map(|field| {
         let ref fieldname = field.name;
         if field.attrs.json {
@@ -133,6 +126,7 @@ pub fn derive_struct(s: &syn::ItemStruct) -> syn::Result<TokenStream> {
                 -> Result<Self, ::edgedb_protocol::errors::DecodeError>
             {
                 let nfields = #base_fields
+                    + if decoder.has_implicit_id { 1 } else { 0 }
                     + if decoder.has_implicit_tid { 1 } else { 0 }
                     + if decoder.has_implicit_tname { 1 } else { 0 };
                 let mut elements =

--- a/edgedb-derive/tests/json.rs
+++ b/edgedb-derive/tests/json.rs
@@ -23,6 +23,7 @@ struct JsonRow {
 
 fn old_decoder() -> Decoder {
     let mut dec = Decoder::default();
+    dec.has_implicit_id = true;
     dec.has_implicit_tid = true;
     return dec;
 }

--- a/edgedb-derive/tests/list_scalar_types.rs
+++ b/edgedb-derive/tests/list_scalar_types.rs
@@ -10,19 +10,20 @@ struct ScalarType {
 
 fn old_decoder() -> Decoder {
     let mut dec = Decoder::default();
+    dec.has_implicit_id = true;
     dec.has_implicit_tid = true;
     return dec;
 }
 
 #[test]
 fn decode_new() {
-    let data = b"\0\0\0\x04\0\0\x0b\x86\0\0\0\x10\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
-        \x01\x0c\0\0\0\x19\0\0\0\x0fcal::local_date\
-        \0\0\0\x19\0\0\0\x0estd::anyscalar\0\0\0\x19\0\0\0\x06normal";
+    let data = b"\0\0\0\x03\0\0\0\x19\0\0\0\x0fcal::local_date\
+               \0\0\0\x19\0\0\0 std::anyscalar, std::anydiscrete\
+               \0\0\0\x19\0\0\0\x06normal";
     let res = ScalarType::decode(&Decoder::default(), data);
     assert_eq!(res.unwrap(), ScalarType {
         name: "cal::local_date".into(),
-        extending: "std::anyscalar".into(),
+        extending: "std::anyscalar, std::anydiscrete".into(),
         kind: "normal".into(),
     });
 }

--- a/edgedb-protocol/src/query_result.rs
+++ b/edgedb-protocol/src/query_result.rs
@@ -40,6 +40,7 @@ impl<T: Queryable> QueryResult for T {
         T::check_descriptor(ctx, root_pos)
             .map_err(DescriptorMismatch::with_source)?;
         Ok(Decoder {
+            has_implicit_id: ctx.has_implicit_id,
             has_implicit_tid: ctx.has_implicit_tid,
             has_implicit_tname: ctx.has_implicit_tname,
         })

--- a/edgedb-protocol/src/queryable.rs
+++ b/edgedb-protocol/src/queryable.rs
@@ -10,6 +10,7 @@ use crate::descriptors::{Descriptor, TypePos};
 
 #[non_exhaustive]
 pub struct Decoder {
+    pub has_implicit_id: bool,
     pub has_implicit_tid: bool,
     pub has_implicit_tname: bool,
 }
@@ -17,6 +18,7 @@ pub struct Decoder {
 impl Default for Decoder {
     fn default() -> Decoder {
         Decoder {
+            has_implicit_id: false,
             has_implicit_tid: false,
             has_implicit_tname: false,
         }
@@ -52,6 +54,7 @@ pub enum DescriptorMismatch {
 }
 
 pub struct DescriptorContext<'a> {
+    pub has_implicit_id: bool,
     pub has_implicit_tid: bool,
     pub has_implicit_tname: bool,
     descriptors: &'a [Descriptor],
@@ -61,6 +64,7 @@ impl DescriptorContext<'_> {
     pub(crate) fn new(descriptors: &[Descriptor]) -> DescriptorContext {
         DescriptorContext {
             descriptors,
+            has_implicit_id: false,
             has_implicit_tid: false,
             has_implicit_tname: false,
         }

--- a/edgedb-tokio/tests/func/derive.rs
+++ b/edgedb-tokio/tests/func/derive.rs
@@ -1,0 +1,63 @@
+use edgedb_tokio::Client;
+use edgedb_derive::Queryable;
+use edgedb_protocol::model::Uuid;
+
+use crate::server::SERVER;
+
+#[derive(Queryable, Debug, PartialEq)]
+struct FreeOb {
+    one: i64,
+    two: i64,
+}
+
+#[derive(Queryable, Debug, PartialEq)]
+struct SchemaType {
+    name: String,
+}
+
+#[derive(Queryable, Debug, PartialEq)]
+struct SchemaTypeId {
+    id: Uuid,
+    name: String,
+}
+
+#[tokio::test]
+async fn free_object() -> anyhow::Result<()> {
+    let client = Client::new(&SERVER.config);
+    client.ensure_connected().await?;
+
+    let value = client.query_required_single::<FreeOb, _>(
+        "SELECT { one := 1, two := 2 }", &()).await?;
+    assert_eq!(value, FreeOb {
+        one: 1,
+        two: 2,
+    });
+
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn schema_type() -> anyhow::Result<()> {
+    let client = Client::new(&SERVER.config);
+    client.ensure_connected().await?;
+
+    let value = client.query_required_single::<SchemaType, _>("
+        SELECT schema::ObjectType { name }
+        FILTER .name = 'schema::Object'
+        LIMIT 1
+        ", &()).await?;
+    assert_eq!(value, SchemaType {
+        name: "schema::Object".into(),
+    });
+
+    let value = client.query_required_single::<SchemaTypeId, _>("
+        SELECT schema::ObjectType { id, name }
+        FILTER .name = 'schema::Object'
+        LIMIT 1
+        ", &()).await?;
+    // id is unstable
+    assert_eq!(value.name, "schema::Object");
+
+    Ok(())
+}

--- a/edgedb-tokio/tests/func/main.rs
+++ b/edgedb-tokio/tests/func/main.rs
@@ -12,3 +12,6 @@ mod transactions;
 
 #[cfg(not(windows))]
 mod globals;
+
+#[cfg(not(windows))]
+mod derive;


### PR DESCRIPTION
This also doesn't automatically match `id` column in the object to the implicit column. Explicit column is needed in the query.

Fixes #175