### PR TITLE
Allow ddl

### DIFF
--- a/edgedb-tokio/src/client.rs
+++ b/edgedb-tokio/src/client.rs
@@ -82,7 +82,7 @@ impl Client {
                 implicit_typenames: false,
                 implicit_typeids: false,
                 explicit_objectids: true,
-                allow_capabilities: Capabilities::ALL,
+                allow_capabilities: Capabilities::MODIFICATIONS | Capabilities::DDL,
                 io_format: IoFormat::Binary,
                 expected_cardinality: Cardinality::Many,
             };
@@ -183,7 +183,7 @@ impl Client {
                 implicit_typenames: false,
                 implicit_typeids: false,
                 explicit_objectids: true,
-                allow_capabilities: Capabilities::ALL,
+                allow_capabilities: Capabilities::MODIFICATIONS | Capabilities::DDL,
                 io_format: IoFormat::Binary,
                 expected_cardinality: Cardinality::AtMostOne,
             };
@@ -304,7 +304,7 @@ impl Client {
                 implicit_typenames: false,
                 implicit_typeids: false,
                 explicit_objectids: true,
-                allow_capabilities: Capabilities::ALL,
+                allow_capabilities: Capabilities::MODIFICATIONS | Capabilities::DDL,
                 io_format: IoFormat::Json,
                 expected_cardinality: Cardinality::Many,
             };
@@ -401,7 +401,7 @@ impl Client {
                 implicit_typenames: false,
                 implicit_typeids: false,
                 explicit_objectids: true,
-                allow_capabilities: Capabilities::ALL,
+                allow_capabilities: Capabilities::MODIFICATIONS | Capabilities::DDL,
                 io_format: IoFormat::Json,
                 expected_cardinality: Cardinality::AtMostOne,
             };

--- a/edgedb-tokio/src/client.rs
+++ b/edgedb-tokio/src/client.rs
@@ -82,7 +82,7 @@ impl Client {
                 implicit_typenames: false,
                 implicit_typeids: false,
                 explicit_objectids: true,
-                allow_capabilities: Capabilities::MODIFICATIONS,
+                allow_capabilities: Capabilities::ALL,
                 io_format: IoFormat::Binary,
                 expected_cardinality: Cardinality::Many,
             };
@@ -183,7 +183,7 @@ impl Client {
                 implicit_typenames: false,
                 implicit_typeids: false,
                 explicit_objectids: true,
-                allow_capabilities: Capabilities::MODIFICATIONS,
+                allow_capabilities: Capabilities::ALL,
                 io_format: IoFormat::Binary,
                 expected_cardinality: Cardinality::AtMostOne,
             };
@@ -304,7 +304,7 @@ impl Client {
                 implicit_typenames: false,
                 implicit_typeids: false,
                 explicit_objectids: true,
-                allow_capabilities: Capabilities::MODIFICATIONS,
+                allow_capabilities: Capabilities::ALL,
                 io_format: IoFormat::Json,
                 expected_cardinality: Cardinality::Many,
             };
@@ -401,7 +401,7 @@ impl Client {
                 implicit_typenames: false,
                 implicit_typeids: false,
                 explicit_objectids: true,
-                allow_capabilities: Capabilities::MODIFICATIONS,
+                allow_capabilities: Capabilities::ALL,
                 io_format: IoFormat::Json,
                 expected_cardinality: Cardinality::AtMostOne,
             };


### PR DESCRIPTION
Change the edgdbe-rust tokio client to allow DDL queries.

This feature was discussed in https://github.com/edgedb/edgedb-rust/issues/183.