### PR TITLE
Allow ddl

### DIFF
--- a/edgedb-tokio/src/client.rs
+++ b/edgedb-tokio/src/client.rs
@@ -82,7 +82,7 @@ impl Client {
                 implicit_typenames: false,
                 implicit_typeids: false,
                 explicit_objectids: true,
-                allow_capabilities: Capabilities::ALL,
+                allow_capabilities: Capabilities::MODIFICATIONS | Capabilities::DDL,
                 io_format: IoFormat::Binary,
                 expected_cardinality: Cardinality::Many,
             };
@@ -183,7 +183,7 @@ impl Client {
                 implicit_typenames: false,
                 implicit_typeids: false,
                 explicit_objectids: true,
-                allow_capabilities: Capabilities::ALL,
+                allow_capabilities: Capabilities::MODIFICATIONS | Capabilities::DDL,
                 io_format: IoFormat::Binary,
                 expected_cardinality: Cardinality::AtMostOne,
             };
@@ -304,7 +304,7 @@ impl Client {
                 implicit_typenames: false,
                 implicit_typeids: false,
                 explicit_objectids: true,
-                allow_capabilities: Capabilities::ALL,
+                allow_capabilities: Capabilities::MODIFICATIONS | Capabilities::DDL,
                 io_format: IoFormat::Json,
                 expected_cardinality: Cardinality::Many,
             };
@@ -401,7 +401,7 @@ impl Client {
                 implicit_typenames: false,
                 implicit_typeids: false,
                 explicit_objectids: true,
-                allow_capabilities: Capabilities::ALL,
+                allow_capabilities: Capabilities::MODIFICATIONS | Capabilities::DDL,
                 io_format: IoFormat::Json,
                 expected_cardinality: Cardinality::AtMostOne,
             };

--- a/edgedb-tokio/src/client.rs
+++ b/edgedb-tokio/src/client.rs
@@ -82,7 +82,7 @@ impl Client {
                 implicit_typenames: false,
                 implicit_typeids: false,
                 explicit_objectids: true,
-                allow_capabilities: Capabilities::MODIFICATIONS,
+                allow_capabilities: Capabilities::ALL,
                 io_format: IoFormat::Binary,
                 expected_cardinality: Cardinality::Many,
             };
@@ -183,7 +183,7 @@ impl Client {
                 implicit_typenames: false,
                 implicit_typeids: false,
                 explicit_objectids: true,
-                allow_capabilities: Capabilities::MODIFICATIONS,
+                allow_capabilities: Capabilities::ALL,
                 io_format: IoFormat::Binary,
                 expected_cardinality: Cardinality::AtMostOne,
             };
@@ -304,7 +304,7 @@ impl Client {
                 implicit_typenames: false,
                 implicit_typeids: false,
                 explicit_objectids: true,
-                allow_capabilities: Capabilities::MODIFICATIONS,
+                allow_capabilities: Capabilities::ALL,
                 io_format: IoFormat::Json,
                 expected_cardinality: Cardinality::Many,
             };
@@ -401,7 +401,7 @@ impl Client {
                 implicit_typenames: false,
                 implicit_typeids: false,
                 explicit_objectids: true,
-                allow_capabilities: Capabilities::MODIFICATIONS,
+                allow_capabilities: Capabilities::ALL,
                 io_format: IoFormat::Json,
                 expected_cardinality: Cardinality::AtMostOne,
             };


### PR DESCRIPTION
This adds the capability to use DDL in the edgedb-tokio client.

This has been discussed in https://github.com/edgedb/edgedb-rust/issues/183

I had to close the original pull request to amend my author  email address.