### PR TITLE
protocol: Allow using chrono types as Queryable

### DIFF
--- a/edgedb-protocol/src/serialization/decode.rs
+++ b/edgedb-protocol/src/serialization/decode.rs
@@ -2,6 +2,9 @@ mod raw_scalar;
 mod raw_composite;
 pub(crate) mod queryable;
 
+#[cfg(feature="chrono")]
+mod chrono;
+
 pub use self::raw_composite::DecodeTupleLike;
 pub(crate) use self::raw_scalar::RawCodec;
 pub(crate) use self::raw_composite::DecodeArrayLike;

--- a/edgedb-protocol/src/serialization/decode/chrono.rs
+++ b/edgedb-protocol/src/serialization/decode/chrono.rs
@@ -1,0 +1,28 @@
+use chrono::{DateTime, NaiveDateTime, NaiveDate, NaiveTime, Utc};
+use crate::errors::DecodeError;
+use crate::serialization::decode::raw_scalar::RawCodec;
+
+
+impl<'t> RawCodec<'t> for DateTime<Utc> {
+    fn decode(buf: &[u8]) -> Result<Self, DecodeError> {
+        crate::model::Datetime::decode(buf).map(Into::into)
+    }
+}
+
+impl<'t> RawCodec<'t> for NaiveDateTime {
+    fn decode(buf: &[u8]) -> Result<Self, DecodeError> {
+        crate::model::LocalDatetime::decode(buf).map(Into::into)
+    }
+}
+
+impl<'t> RawCodec<'t> for NaiveDate {
+    fn decode(buf: &[u8]) -> Result<Self, DecodeError> {
+        crate::model::LocalDate::decode(buf).map(Into::into)
+    }
+}
+
+impl<'t> RawCodec<'t> for NaiveTime {
+    fn decode(buf: &[u8]) -> Result<Self, DecodeError> {
+        crate::model::LocalTime::decode(buf).map(Into::into)
+    }
+}

--- a/edgedb-protocol/src/serialization/decode/raw_scalar.rs
+++ b/edgedb-protocol/src/serialization/decode/raw_scalar.rs
@@ -546,6 +546,13 @@ impl<'t> RawCodec<'t> for Duration {
     }
 }
 
+impl<'t> RawCodec<'t> for std::time::Duration {
+    fn decode(buf: &[u8]) -> Result<Self, DecodeError> {
+        let dur = Duration::decode(buf)?;
+        dur.try_into().map_err(|_| errors::InvalidDate.build())
+    }
+}
+
 impl ScalarArg for Duration {
     fn encode(&self, encoder: &mut Encoder)
         -> Result<(), Error>
@@ -603,17 +610,8 @@ impl ScalarArg for RelativeDuration {
 
 impl<'t> RawCodec<'t> for SystemTime {
     fn decode(buf: &[u8]) -> Result<Self, DecodeError> {
-        let micros = i64::decode(buf)?;
-
-        use std::time::{ Duration, UNIX_EPOCH };
-        let postgres_epoch :SystemTime = UNIX_EPOCH + Duration::from_secs(946684800);
-
-        let val = if micros > 0 {
-            postgres_epoch + Duration::from_micros(micros as u64)
-        } else {
-            postgres_epoch - Duration::from_micros((-micros) as u64)
-        };
-        Ok(val)
+        let dur = Datetime::decode(buf)?;
+        dur.try_into().map_err(|_| errors::InvalidDate.build())
     }
 }
 
@@ -668,7 +666,8 @@ impl ScalarArg for Datetime {
 impl<'t> RawCodec<'t> for LocalDatetime {
     fn decode(buf: &[u8]) -> Result<Self, DecodeError> {
         let micros = i64::decode(buf)?;
-        Ok(LocalDatetime { micros })
+        LocalDatetime::from_postgres_micros(micros)
+           .map_err(|_| errors::InvalidDate.build())
     }
 }
 


### PR DESCRIPTION
Also simplifies conversions from EdgeDB datetime types to chrono types as latter always has a bigger range of values than EdgeDB.

Fixes #198