### PR TITLE
Add `AsEdgedbError` trait and `TransactionError` type

### DIFF
--- a/edgedb-errors/Cargo.toml
+++ b/edgedb-errors/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 [dependencies]
 bytes = "1.0.1"
 miette = { version="5.3.0", optional=true }
+anyhow = { version="1.0", optional=true }
 
 [dev-dependencies]
 tokio = "1.0"

--- a/edgedb-errors/src/lib.rs
+++ b/edgedb-errors/src/lib.rs
@@ -146,6 +146,7 @@
 //!
 mod error;
 mod traits;
+mod transaction;
 
 pub mod display;
 pub mod kinds;
@@ -154,6 +155,7 @@ pub mod fields;
 #[cfg(feature="miette")]
 pub mod miette;
 
-pub use traits::{ErrorKind, ResultExt, Field};
+pub use traits::{ErrorKind, ResultExt, Field, AsEdgedbError};
+pub use transaction::{TransactionError};
 pub use error::{Error, Tag};
 pub use kinds::*;

--- a/edgedb-errors/src/miette.rs
+++ b/edgedb-errors/src/miette.rs
@@ -8,6 +8,7 @@ use miette::{SourceCode, LabeledSpan};
 
 use crate::Error;
 use crate::fields::QueryText;
+use crate::traits::AsEdgedbError;
 
 impl miette::Diagnostic for Error {
     fn code(&self) -> Option<Box<dyn Display + '_>> {
@@ -25,5 +26,11 @@ impl miette::Diagnostic for Error {
     }
     fn help(&self) -> Option<Box<dyn Display + '_>> {
         self.details().map(|v| Box::new(v) as Box<dyn Display>)
+    }
+}
+
+impl AsEdgedbError for miette::Report {
+    fn as_edgedb_error(&self) -> Option<&Error> {
+        self.downcast_ref()
     }
 }

--- a/edgedb-errors/src/traits.rs
+++ b/edgedb-errors/src/traits.rs
@@ -57,12 +57,29 @@ pub trait Field {
     type Value: Send + Sync + 'static;
 }
 
+pub trait AsEdgedbError {
+    fn as_edgedb_error(&self) -> Option<&Error>;
+}
+
 pub trait ResultExt<T> {
     fn context<C>(self, context: C) -> Result<T, Error>
         where C: Into<Cow<'static, str>>;
     fn with_context<C, F>(self, f: F) -> Result<T, Error>
         where C: Into<Cow<'static, str>>,
               F: FnOnce() -> C;
+}
+
+impl AsEdgedbError for Error {
+    fn as_edgedb_error(&self) -> Option<&Error> {
+        Some(self)
+    }
+}
+
+#[cfg(feature="anyhow")]
+impl AsEdgedbError for anyhow::Error {
+    fn as_edgedb_error(&self) -> Option<&Error> {
+        self.downcast_ref()
+    }
 }
 
 impl<T> ResultExt<T> for Result<T, Error> {

--- a/edgedb-errors/src/transaction.rs
+++ b/edgedb-errors/src/transaction.rs
@@ -1,0 +1,22 @@
+use crate::Error;
+use crate::traits::AsEdgedbError;
+
+pub enum TransactionError<E> {
+    Edgedb(Error),
+    User(E),
+}
+
+impl<E> From<Error> for TransactionError<E> {
+    fn from(e: Error) -> TransactionError<E> {
+        TransactionError::Edgedb(e)
+    }
+}
+
+impl<E> AsEdgedbError for TransactionError<E> {
+    fn as_edgedb_error(&self) -> Option<&Error> {
+        match self {
+            TransactionError::Edgedb(e) => Some(e),
+            TransactionError::User(_) => None,
+        }
+    }
+}

--- a/edgedb-tokio/examples/transaction_errors2.rs
+++ b/edgedb-tokio/examples/transaction_errors2.rs
@@ -1,0 +1,41 @@
+use std::error::Error;
+use rand::{thread_rng, Rng};
+
+use edgedb_errors::{ErrorKind, UserError};
+
+#[derive(thiserror::Error, Debug)]
+#[error("should not apply this counter update")]
+struct CounterError;
+
+
+fn check_val1(val: i64) -> Result<(), CounterError> {
+    if val % 3 == 1 {
+        if thread_rng().gen_bool(0.1) {
+            return Err(CounterError)?;
+        }
+    }
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    env_logger::init();
+    let conn = edgedb_tokio::create_client().await?;
+    let res = conn.transaction(|mut transaction| async move {
+        let val = transaction.query_required_single::<i64, _>("
+                WITH counter := (UPDATE Counter SET { value := .value + 1}),
+                SELECT counter.value LIMIT 1
+            ", &(),
+        ).await?;
+        check_val1(val)?;
+        anyhow::Ok(val)
+    }).await;
+    match res {
+        Ok(val) => println!("New counter value: {val}"),
+        Err(e) if e.source().map_or(false, |e| e.is::<CounterError>()) => {
+            println!("Skipping: {e:#}");
+        }
+        Err(e) => return Err(e)?,
+    }
+    Ok(())
+}

--- a/edgedb-tokio/examples/transaction_errors3.rs
+++ b/edgedb-tokio/examples/transaction_errors3.rs
@@ -1,0 +1,41 @@
+use std::error::Error;
+use rand::{thread_rng, Rng};
+
+use edgedb_errors::{ErrorKind, UserError, TransactionError};
+
+#[derive(thiserror::Error, Debug)]
+#[error("should not apply this counter update")]
+struct CounterError;
+
+
+fn check_val1(val: i64) -> Result<(), CounterError> {
+    if val % 3 == 1 {
+        if thread_rng().gen_bool(0.1) {
+            return Err(CounterError)?;
+        }
+    }
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    env_logger::init();
+    let conn = edgedb_tokio::create_client().await?;
+    let res = conn.transaction(|mut transaction| async move {
+        let val = transaction.query_required_single::<i64, _>("
+                WITH counter := (UPDATE Counter SET { value := .value + 1}),
+                SELECT counter.value LIMIT 1
+            ", &(),
+        ).await?;
+        check_val1(val).map_err(TransactionError::User)?;
+        Ok::<_, TransactionError<CounterError>>(val)
+    }).await;
+    match res {
+        Ok(val) => println!("New counter value: {val}"),
+        Err(TransactionError::User(e)) => {
+            println!("Skipping: {e:#}");
+        }
+        Err(TransactionError::Edgedb(e)) => return Err(e)?,
+    }
+    Ok(())
+}

--- a/edgedb-tokio/src/client.rs
+++ b/edgedb-tokio/src/client.rs
@@ -2,11 +2,12 @@ use std::sync::Arc;
 use std::future::Future;
 
 use bytes::BytesMut;
-use edgedb_protocol::model::Json;
+use edgedb_errors::AsEdgedbError;
+use edgedb_protocol::QueryResult;
 use edgedb_protocol::common::CompilationOptions;
 use edgedb_protocol::common::{IoFormat, Capabilities, Cardinality};
+use edgedb_protocol::model::Json;
 use edgedb_protocol::query_arg::{QueryArgs, Encoder};
-use edgedb_protocol::QueryResult;
 use tokio::time::sleep;
 
 use crate::raw::{Pool, QueryCapabilities};
@@ -434,9 +435,10 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn transaction<T, B, F>(self, body: B) -> Result<T, Error>
+    pub async fn transaction<T, B, F, E>(self, body: B) -> Result<T, E>
         where B: FnMut(Transaction) -> F,
-              F: Future<Output=Result<T, Error>>,
+              F: Future<Output=Result<T, E>>,
+              E: AsEdgedbError + From<Error>,
     {
         transaction(&self.pool, &self.options, body).await
     }

--- a/edgedb-tokio/tests/func/transactions.rs
+++ b/edgedb-tokio/tests/func/transactions.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering};
 
 use tokio::sync::{Mutex};
 
-use edgedb_tokio::{Client, Transaction};
+use edgedb_tokio::{Client, Transaction, Error};
 
 use crate::server::SERVER;
 
@@ -51,7 +51,7 @@ async fn transaction1(client: Client, name: &str, iterations: Arc<AtomicUsize>,
                         ).value
                     ", &(name,)).await?
             };
-            Ok(val)
+            Ok::<_, Error>(val)
         }
     }).await?;
     Ok(val)
@@ -114,7 +114,7 @@ async fn transaction1e(
             barrier.wait().await;
             let _lock = lock.lock().await;
             let val = get_counter_value(&mut tx, name).await?;
-            Ok(val)
+            Ok::<_, Error>(val)
         }
     }).await?;
     Ok(val)


### PR DESCRIPTION
Trying to improve the situation with errors in transaction.

This adds a trait and instead of requiring concrete type from transaction it returns a trait. So you can use different types for transactions.

Inspired by discussion in #171