### PR TITLE
Update dependencies to clean security advisories

### DIFF
--- a/edgedb-protocol/Cargo.toml
+++ b/edgedb-protocol/Cargo.toml
@@ -18,7 +18,7 @@ uuid = "1.1.2"
 num-bigint = {version="0.4.3", optional=true}
 num-traits = {version="0.2.10", optional=true}
 bigdecimal = {version="0.3.0", optional=true}
-chrono = {version="0.4.23", optional=true}
+chrono = {version="0.4.23", optional=true, features=["std"], default-features=false}
 edgedb-errors = {path = "../edgedb-errors", version="0.3.0"}
 bitflags = "1.3.2"
 

--- a/edgedb-tokio/Cargo.toml
+++ b/edgedb-tokio/Cargo.toml
@@ -23,9 +23,9 @@ base16ct = {version="0.1.1", features=["alloc"]}
 log = "0.4.8"
 rand = "0.8"
 url = "2.1.1"
-tls-api = {version="0.7.0", default-features=false, features=["runtime-tokio"]}
-tls-api-not-tls = {version="0.7.0", default-features=false, features=["runtime-tokio"]}
-tls-api-rustls = {version="0.7.0", default-features=false, features=["runtime-tokio"]}
+tls-api = {version="0.9.0", default-features=false, features=["runtime-tokio"]}
+tls-api-not-tls = {version="0.9.0", default-features=false, features=["runtime-tokio"]}
+tls-api-rustls = {version="0.9.0", default-features=false, features=["runtime-tokio"]}
 rustls = {version="0.20.2", features=[
     "dangerous_configuration",  # this allows insecure mode
 ]}

--- a/vagga.yaml
+++ b/vagga.yaml
@@ -88,10 +88,10 @@ commands:
     container: tools
     run: [cargo, outdated]
 
-  fuzz: !Command
-    description: Run fuzz tool
+  audit: !Command
+    description: Run audit tool
     container: tools
-    run: [cargo, fuzz]
+    run: [cargo, audit]
 
   example-tokio: !Command
     description: Run named tokio example
@@ -192,7 +192,7 @@ containers:
   tools:
     setup:
     - !Container ubuntu
-    - !Sh 'cargo install cargo-fuzz cargo-outdated --root=/usr'
+    - !Sh 'cargo install cargo-audit cargo-outdated --root=/usr'
     environ: *environ
 
   nightly:


### PR DESCRIPTION
Includes disabling default features on `chrono` crate.