### PR TITLE
Add clarification that field order matters

### DIFF
--- a/edgedb-derive/src/lib.rs
+++ b/edgedb-derive/src/lib.rs
@@ -15,9 +15,9 @@ mod variables;
 ///
 /// This derive can be used on structures with named fields (which correspond
 /// to "shapes" in EdgeDB). Note that field order matters, so the struct below
-/// corresponds to an EdgeDB `User` type with `first_name` followed by `age`.
+/// corresponds to an EdgeDB `User` query with `first_name` followed by `age`.
 /// A `DescriptorMismatch` will be returned if the fields in the Rust struct
-/// are not in the same order as type in the EdgeDB schema.
+/// are not in the same order as those in the query shape.
 ///
 /// ```rust
 /// #[derive(edgedb_derive::Queryable)]

--- a/edgedb-derive/src/lib.rs
+++ b/edgedb-derive/src/lib.rs
@@ -14,7 +14,10 @@ mod variables;
 /// queries.
 ///
 /// This derive can be used on structures with named fields (which correspond
-/// to "shapes" in EdgeDB).
+/// to "shapes" in EdgeDB). Note that field order matters, so the struct below
+/// corresponds to an EdgeDB `User` type with `first_name` followed by `age`.
+/// A `DescriptorMismatch` will be returned if the fields in the Rust struct
+/// are not in the same order as type in the EdgeDB schema.
 ///
 /// ```rust
 /// #[derive(edgedb_derive::Queryable)]


### PR DESCRIPTION
Adding a note that field order matters when using Queryable (noticed this today).