### PR TITLE
Make command-fds unix only

### DIFF
--- a/edgedb-tokio/Cargo.toml
+++ b/edgedb-tokio/Cargo.toml
@@ -42,7 +42,7 @@ tokio-stream = {version="0.1.11", optional=true}
 base64 = "0.13"
 crc16 = "0.4.0"
 
-[target.'cfg(target_os = "linux")'.dev-dependencies]
+[target.'cfg(not(target_os="windows"))'.dev-dependencies]
 command-fds = "0.2.1"
 
 [dev-dependencies]

--- a/edgedb-tokio/Cargo.toml
+++ b/edgedb-tokio/Cargo.toml
@@ -42,9 +42,11 @@ tokio-stream = {version="0.1.11", optional=true}
 base64 = "0.13"
 crc16 = "0.4.0"
 
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+command-fds = "0.2.1"
+
 [dev-dependencies]
 nix = "0.23.1"
-command-fds = "0.2.1"
 shutdown_hooks = "0.1.0"
 env_logger = "0.9"
 thiserror = "1.0.30"

--- a/edgedb-tokio/Cargo.toml
+++ b/edgedb-tokio/Cargo.toml
@@ -42,7 +42,7 @@ tokio-stream = {version="0.1.11", optional=true}
 base64 = "0.13"
 crc16 = "0.4.0"
 
-[target.'cfg(not(target_os="windows"))'.dev-dependencies]
+[target.'cfg(target_family="unix")'.dev-dependencies]
 command-fds = "0.2.1"
 
 [dev-dependencies]


### PR DESCRIPTION
Makes command-fds dependency unix only to allow compiling tests and examples on Windows.

Note: only a single change - was experimenting with various changes to see the workflow output.