### PR TITLE
Export `InstanceName`

### DIFF
--- a/edgedb-tokio/src/builder.rs
+++ b/edgedb-tokio/src/builder.rs
@@ -132,8 +132,9 @@ struct DsnHelper<'a> {
     query: HashMap<Cow<'a, str>, Cow<'a, str>>,
 }
 
+/// Parsed EdgeDB instance name.
 #[derive(Clone, Debug)]
-enum InstanceName {
+pub enum InstanceName {
     Local(String),
     Cloud {
         org_slug: String,
@@ -1632,6 +1633,10 @@ impl Config {
             Some(InstanceName::Local(ref name)) => Some(name),
             _ => None,
         }
+    }
+
+    pub fn instance_name(&self) -> Option<&InstanceName> {
+        self.0.instance_name.as_ref()
     }
 
     /// Secret key if set

--- a/edgedb-tokio/src/lib.rs
+++ b/edgedb-tokio/src/lib.rs
@@ -56,7 +56,7 @@ mod transaction;
 
 pub use edgedb_derive::{Queryable, GlobalsDelta, ConfigDelta};
 
-pub use builder::{Builder, Config};
+pub use builder::{Builder, Config, InstanceName};
 pub use credentials::TlsSecurity;
 pub use client::Client;
 pub use errors::Error;


### PR DESCRIPTION
Ideally, this should be unified with CLI's instance name option parsing,
but for now just export the binding's version for cases where the
instance name is not specified as an explicit argument.
