### PR TITLE
Export `ClientSecurity`

### DIFF
--- a/edgedb-tokio/src/lib.rs
+++ b/edgedb-tokio/src/lib.rs
@@ -56,7 +56,7 @@ mod transaction;
 
 pub use edgedb_derive::{Queryable, GlobalsDelta, ConfigDelta};
 
-pub use builder::{Builder, Config, InstanceName};
+pub use builder::{Builder, Config, InstanceName, ClientSecurity};
 pub use credentials::TlsSecurity;
 pub use client::Client;
 pub use errors::Error;


### PR DESCRIPTION
Fixes configuring `client_security` on a `Builder` is currently broken due to `ClientSecurity` being private. 