### PR TITLE
Add RetryCondition to pub use

### DIFF
--- a/edgedb-tokio/src/lib.rs
+++ b/edgedb-tokio/src/lib.rs
@@ -60,7 +60,7 @@ pub use builder::{Builder, Config, InstanceName, ClientSecurity};
 pub use credentials::TlsSecurity;
 pub use client::Client;
 pub use errors::Error;
-pub use options::{TransactionOptions, RetryOptions};
+pub use options::{TransactionOptions, RetryOptions, RetryCondition};
 pub use state::{GlobalsDelta, ConfigDelta};
 pub use transaction::{Transaction};
 


### PR DESCRIPTION
Small thing I noticed today: can't use the `with_rule` method when changing retry options for the client as `RetryCondition` isn't pub and neither is `mod options`.