### PR TITLE
Fix Miette docs.rs link

### DIFF
--- a/edgedb-errors/src/miette.rs
+++ b/edgedb-errors/src/miette.rs
@@ -1,6 +1,6 @@
 //! Miette support for EdgeDB error
 //!
-//! [miette](https://docs.io/miette) allows nice formatting of error
+//! [miette](https://docs.rs/miette) allows nice formatting of error
 //!
 use std::fmt::Display;
 use miette::{SourceCode, LabeledSpan};


### PR DESCRIPTION
It used to link to [docs.io](http://docs.io), which for some reason redirects to a Microsoft website. I'm assuming it meant [docs.rs](https://docs.rs).