### PR TITLE
Rv unsafe from new unchecked

### DIFF
--- a/edgedb-protocol/src/model/json.rs
+++ b/edgedb-protocol/src/model/json.rs
@@ -3,9 +3,6 @@
 pub struct Json(String);
 
 impl Json {
-    pub(crate) fn _new_unchecked(value: String) -> Json {
-        Json(value)
-    }
     /// Create a JSON value without checking the contents.
     ///
     /// Two examples of use:

--- a/edgedb-protocol/src/model/json.rs
+++ b/edgedb-protocol/src/model/json.rs
@@ -8,9 +8,16 @@ impl Json {
     }
     /// Create a JSON value without checking the contents.
     ///
-    /// This is used to construct values with the data received from the
+    /// Two examples of use:
+    /// 
+    /// 1) To construct values with the data received from the
     /// database, because we trust database to produce valid JSON.
-    pub unsafe fn new_unchecked(value: String) -> Json {
+    /// 
+    /// 2) By client users who are using data that is guaranteed
+    /// to be valid JSON. If unsure, using a method such as serde_json's
+    /// [to_string](https://docs.rs/serde_json/latest/serde_json/ser/fn.to_string.html) to
+    /// construct a String is highly recommended.
+    pub fn new_unchecked(value: String) -> Json {
         Json(value)
     }
 }

--- a/edgedb-protocol/src/model/json.rs
+++ b/edgedb-protocol/src/model/json.rs
@@ -14,6 +14,10 @@ impl Json {
     /// to be valid JSON. If unsure, using a method such as serde_json's
     /// [to_string](https://docs.rs/serde_json/latest/serde_json/ser/fn.to_string.html) to
     /// construct a String is highly recommended.
+    /// 
+    /// When used in a client query method, EdgeDB itself will recognize if the 
+    /// String inside `Json` is invalid JSON by returning `InvalidValueError:
+    /// invalid input syntax for type json`.
     pub fn new_unchecked(value: String) -> Json {
         Json(value)
     }

--- a/edgedb-protocol/src/serialization/decode/raw_scalar.rs
+++ b/edgedb-protocol/src/serialization/decode/raw_scalar.rs
@@ -128,7 +128,7 @@ impl<'t> RawCodec<'t> for Json {
         let val = str::from_utf8(buf)
             .context(errors::InvalidUtf8)?
             .to_owned();
-        Ok(Json::_new_unchecked(val))
+        Ok(Json::new_unchecked(val))
     }
 }
 

--- a/edgedb-protocol/src/serialization/test_scalars.rs
+++ b/edgedb-protocol/src/serialization/test_scalars.rs
@@ -56,7 +56,7 @@ fn str() {
 
 #[test]
 fn json() {
-    let val = unsafe { Json::new_unchecked("{}".into()) };
+    let val = Json::new_unchecked("{}".into());
     assert_eq!(&encode(val)[..], b"\x01{}");
     assert_eq!(&decode::<Json>(b"\x01{}")[..], "{}");
 }

--- a/edgedb-protocol/tests/codecs.rs
+++ b/edgedb-protocol/tests/codecs.rs
@@ -716,7 +716,7 @@ fn json() -> Result<(), Box<dyn Error>> {
     )?;
 
     encoding_eq!(&codec, b"\x01\"txt\"",
-        Value::Json(unsafe { Json::new_unchecked(String::from(r#""txt""#)) }));
+        Value::Json(Json::new_unchecked(String::from(r#""txt""#))));
     Ok(())
 }
 

--- a/edgedb-tokio/src/client.rs
+++ b/edgedb-tokio/src/client.rs
@@ -282,7 +282,7 @@ impl Client {
                     if let Some(bytes) = bytes {
                         // we trust database to produce valid json
                         let s = String::decode(&mut state, &bytes)?;
-                        return Ok(unsafe { Json::new_unchecked(s) })
+                        return Ok(Json::new_unchecked(s))
                     } else {
                         return Err(NoDataError::with_message(
                             "query row returned zero results"))
@@ -391,7 +391,7 @@ impl Client {
                     if let Some(bytes) = bytes {
                         // we trust database to produce valid json
                         let s = String::decode(&mut state, &bytes)?;
-                        return Ok(Some(unsafe { Json::new_unchecked(s) }))
+                        return Ok(Some(Json::new_unchecked(s)))
                     } else {
                         return Ok(None)
                     }

--- a/edgedb-tokio/src/transaction.rs
+++ b/edgedb-tokio/src/transaction.rs
@@ -351,7 +351,7 @@ impl Transaction {
                 if let Some(bytes) = bytes {
                     // we trust database to produce valid json
                     let s = String::decode(&mut state, &bytes)?;
-                    Ok(unsafe { Json::new_unchecked(s) })
+                    Ok(Json::new_unchecked(s))
                 } else {
                     Err(NoDataError::with_message(
                         "query row returned zero results"))
@@ -409,7 +409,7 @@ impl Transaction {
                 if let Some(bytes) = bytes {
                     // we trust database to produce valid json
                     let s = String::decode(&mut state, &bytes)?;
-                    Ok(Some(unsafe { Json::new_unchecked(s) }))
+                    Ok(Some(Json::new_unchecked(s)))
                 } else {
                     Ok(None)
                 }


### PR DESCRIPTION
This comes from a recent Discord discussion as well as issue #270 re: constructing Json from a String, which allows a Value to be constructed and thereby to allow a query to take place (one method of many which does involve working with the large Value enum but very solid).

https://discord.com/channels/841451783728529451/1142010632053456918/1142503871474847836

https://github.com/edgedb/edgedb-rust/issues/270

I agree that the function should not be marked as unsafe as there is no possibility of undefined behaviour - there is nothing in here that the compiler can't understand and must be asked to look in the other direction. All that can happen is an error from the database that the input is invalid and a very normal Err is returned:

```
Err(
    Error(
        Inner {
            code: 83951616,
            messages: [
                "invalid input syntax for type json",
            ],
            error: None,
            headers: {
                257: b"edb.errors.InvalidValueError: invalid input syntax for type json\n",
            },
            fields: {
                (
                    "capabilities",
                    TypeId {
                        t: 14307968703009161034,
                    },
                ): Any { .. },
                (
                    "source_code",
                    TypeId {
                        t: 72036081375641672,
                    },
                ): Any { .. },
            },
        },
    ),
)
```

It also removes the only pub unsafe fn in edgedb-rust which is nice.

I gave some thought to putting an impl for Json where J: Serialize (which would add a feature to the edgedb-protocol crate) but feels like overkill/babysitting considering how ubiquitous serde and serde_json are and how lightweight the protocol crate should be. I can't imagine there being anyone who knows about EdgeDB's Rust crates but has never worked with serde or JSON before. So IMO the best thing is simply to remove unsafe, add some documentation and leave it at that.

At the same time we shouldn't add anything as convenient as From<String> for Json as that might give the impression that we are doing something under the hood to validate the String which we are not. The _unchecked part of the function name plus the extra notes should be enough. And the function name itself is quite convenient as _unchecked is seen in a lot of unsafe functions in Rust and will raise the alert level of anyone using it.

Two other changes resulting from the removal of unsafe are:

- Removing some unsafe blocks that are no longer needed,
- Doing away with the _new_unchecked function (note the underscore, it's a different function) that was used internally in a single place but does the same thing: just creates a Json with a String inside.