### PR TITLE
impl DecodeScalar for chrono::DateTime and chrono Naive types

### DIFF
--- a/edgedb-protocol/src/serialization/decode/queryable/scalars.rs
+++ b/edgedb-protocol/src/serialization/decode/queryable/scalars.rs
@@ -151,6 +151,12 @@ impl DecodeScalar for Datetime {
     fn typename() -> &'static str { "std::datetime" }
 }
 
+#[cfg(feature="chrono")]
+impl DecodeScalar for chrono::DateTime<chrono::Utc> {
+    fn uuid() -> Uuid { codec::STD_DATETIME }
+    fn typename() -> &'static str { "std::datetime" }
+}
+
 impl DecodeScalar for ConfigMemory {
     fn uuid() -> Uuid { codec::CFG_MEMORY }
     fn typename() -> &'static str { "cfg::memory" }

--- a/edgedb-protocol/src/serialization/decode/queryable/scalars.rs
+++ b/edgedb-protocol/src/serialization/decode/queryable/scalars.rs
@@ -121,12 +121,30 @@ impl DecodeScalar for LocalDatetime {
     fn typename() -> &'static str { "cal::local_datetime" }
 }
 
+#[cfg(feature="chrono")]
+impl DecodeScalar for chrono::NaiveDateTime {
+    fn uuid() -> Uuid { codec::CAL_LOCAL_DATETIME }
+    fn typename() -> &'static str { "cal::local_datetime" }
+}
+
 impl DecodeScalar for LocalDate {
     fn uuid() -> Uuid { codec::CAL_LOCAL_DATE }
     fn typename() -> &'static str { "cal::local_date" }
 }
 
+#[cfg(feature="chrono")]
+impl DecodeScalar for chrono::NaiveDate {
+    fn uuid() -> Uuid { codec::CAL_LOCAL_DATE }
+    fn typename() -> &'static str { "cal::local_date" }
+}
+
 impl DecodeScalar for LocalTime {
+    fn uuid() -> Uuid { codec::CAL_LOCAL_TIME }
+    fn typename() -> &'static str { "cal::local_time" }
+}
+
+#[cfg(feature="chrono")]
+impl DecodeScalar for chrono::NaiveTime {
     fn uuid() -> Uuid { codec::CAL_LOCAL_TIME }
     fn typename() -> &'static str { "cal::local_time" }
 }


### PR DESCRIPTION
Looking at issue #263 and [another discussion](https://discord.com/channels/841451783728529451/1002645322239054014/1145536753516679309) on Discord today, chrono::Datetime isn't usable with the EdgeDB client yet. It looks like the chrono interop module is already complete though and the only remaining item is to impl DecodeScalar for the type. There are already a few of these DecodeScalar impls for two other major Rust types (BigDecimal and BigInt) and they also have their own interop crates followed by impl DecodeScalar which returns the corresponding EdgeDB standard library types. e.g. here is the code for BigInt along with num_bigint::BigInt, giving the name uuid and typename:

impl DecodeScalar for BigInt {
    fn uuid() -> Uuid { codec::STD_BIGINT }
    fn typename() -> &'static str { "std::bigint" }
}

#[cfg(feature="num-bigint")]
impl DecodeScalar for num_bigint::BigInt {
    fn uuid() -> Uuid { codec::STD_BIGINT }
    fn typename() -> &'static str { "std::bigint" }
}

So looks like Chrono's Datetime is already good to go as far as interop is concerned and is only lacking these lines of code to implement the trait. (Tried this locally as well and queries work once this is added)

Edit: the chrono_interop module also includes Chrono's naive types which correspond to EdgeDB's cal::local types, so have added these three as well.