### PR TITLE
Show timeout and conflicting settings

### DIFF
--- a/edgedb-tokio/src/builder.rs
+++ b/edgedb-tokio/src/builder.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::str::{self, FromStr};
 use std::sync::Arc;
-use std::time::{Duration};
+use std::time::Duration;
 
 use base64::Engine;
 use rustls::client::ServerCertVerifier;
@@ -18,9 +18,8 @@ use tokio::fs;
 use edgedb_protocol::model;
 
 use crate::credentials::{Credentials, TlsSecurity};
-use crate::errors::{ClientError};
 use crate::errors::{ClientNoCredentialsError, NoCloudConfigFound};
-use crate::errors::{Error, ErrorKind, ResultExt};
+use crate::errors::{ClientError, Error, ErrorKind, ResultExt};
 use crate::errors::{InterfaceError, InvalidArgumentError};
 use crate::tls;
 
@@ -93,6 +92,12 @@ pub struct Builder {
 #[derive(Clone)]
 pub struct Config(pub(crate) Arc<ConfigInner>);
 
+impl Config {
+    /// The duration for which the client will attempt to establish a connection.
+    pub fn wait_until_available(&self) -> Duration {
+        self.0.wait
+    }
+}
 
 #[derive(Clone)]
 pub(crate) struct ConfigInner {

--- a/edgedb-tokio/src/credentials.rs
+++ b/edgedb-tokio/src/credentials.rs
@@ -168,8 +168,8 @@ impl<'de> Deserialize<'de> for Credentials {
                 .unwrap_or(false)
         {
             Err(serde::de::Error::custom(format!(
-                "detected conflicting settings: \
-                 tls_security={} but tls_verify_hostname={}",
+                "detected conflicting settings. \
+                 \ntls_security =\n{}\nbut tls_verify_hostname =\n{}",
                 serde_json::to_string(&creds.tls_security)
                     .map_err(serde::de::Error::custom)?,
                 serde_json::to_string(&creds.tls_verify_hostname)
@@ -180,8 +180,8 @@ impl<'de> Deserialize<'de> for Credentials {
             creds.tls_ca != creds.tls_cert_data
         {
             Err(serde::de::Error::custom(format!(
-                "detected conflicting settings: \
-                 tls_ca={:?} but tls_cert_data={:?}",
+                "detected conflicting settings. \
+                 \ntls_ca =\n{:#?}\nbut tls_cert_data =\n{:#?}",
                 creds.tls_ca,
                 creds.tls_cert_data,
             )))


### PR DESCRIPTION
Two very small user-oriented changes.

On the CLI side there are a few things that can go wrong when attempting to connect. One is the port which if wrong will display this and only this for 30 seconds (or another if a different wait_until_available specified):

```
Connecting to EdgeDB instance 'anything' at localhost:10700...
```

A user could specify RUST_LOG="debug" for more info (and considering adding that note as a hint inside the CLI) which shows the multiple connection failures as they happen but if not then it looks like it is just hanging. With a method to see the wait_until_available it could look something like this instead: 

```
Connecting to EdgeDB instance 'anything' at localhost:10700 (will try up to 30s)...
```

The error when tls_cert_data or tls_ca is wrong is good, it's just not spaced out and looks like this.

```
edgedb error: ClientError: cannot read credentials file C:\Users\mithr\AppData\Local\EdgeDB\config\credentials\anything.json: detected conflicting settings: tls_ca=Some("-----BEGIN CERTIFICATE-----\nMIIC0zCCAbugAwIBAgIRAMFs6w0fiU2omuuhw9I7ew0wDQYJKoZIhvcNAQELBQAw\nGDEWMBQGA1UEAwwNRWRnZURCIFNlcnZlcjAeFw0yMzEwMjIxODM4MzNaFw00MjEy\nMjIxODM4MzNaMBgxFjAUBgNVBAMMDUVkZ2VEQiBTZXJ2ZXIwggEiMA0GCSqGSIb3\nDQEBAQUAA4IBDwAwggEKAoIBAQCPDnnf5mcSzOC8MQkGvhBSrBMuQRtCm/YPacLA\nX6zUqIYI9F3tjlcKRtM7Swt6/ZEzsjB97ynZgz1FaU4VdoZ1UxxVQIp47VnwaQ7h\nNRLhHOlYNZHrUT+bUwUhMcGPsR2K6d+R4J4iwGaLEhsjnUVr2Mgmq9cXotXeHWET\nhXmJkurAyCU7bC8sqeA6OllZt2rdxv0j8hfcejgzYO8SBOxN8mqnOO8ZAs75EPjK\nPVMqSAO5y2rYPfTBMgZmCkf7RZrmU1RL/be8/0WBipZcwGUVaNpQ27/sj9Uill/x\n2uTkckbDHHsIO9T2L6YT/Hl4ZzBRQwGUpRGRMRVYwNk0I7xTAgMBAAGjGDAWMBQG\nA1UdEQQNMAuCCWxvY2FsaG9zdDANBgkqhkiG9w0BAQsFAAOCAQEAY8PVKtHRFz8k\noQ+bvSDKcxivgWAzj+11BWcleazQCIDMLmCC9Fb8D9ElNQHaxM3IARbXHK5V7PYz\nZnWSzNMBIvALLd3t5OMUaP44k6CRvMssUJ2NTwdXi9L4pfYVA8HoC9Mu97R+vOIK\nTNC+1MnX7Xk+/OjVqgddi/Zo3QiBKJJ9PQz9uyYADKapMx3kTdgkmQEUp1eM0x2/\nkUeI8d+YyWLSRN6xg6JsQ+4Wu4igzZnUBrg4/+hnAeZkDn6Gr7wcF+7fi26zGNVi\nbtN627XEn8BYvBvg9eIKH9QUQ5bSIEklp/uDTw4XAFI+ulXcHbarF4skJFNAu+Q8\nyuEpkyskTA==\n-----END CERTIFICATE-----\n") but tls_cert_data=Some("-----BEGIN CERTIFICATE-----\nMIIC0zCCAbugAwIBAgIRAMFs6w0fiU2omuuhw9I7ew0wDQYJKoZIhvcNAQELBQAw\nGDEWMBQGA1UEAwwNRWRnZURCIFNlcnZlcjAeFw0yMzEwMjIxODM4MzNaFw00MjEy\nMjIxODM4MzNaMBgxFjAUBgNVBAMMDUVkZ2VEQiBTZXJ2ZXIwggEiMA0GCSqGSIb3\nDQEBAQUAA4IBDwAwggEKAoIBAQCPDnnf5mcSzOC8MQkGvhBSrBMuQRtCm/YPacLA\nX6zUqIYI9F3tjlcKRtM7Swt6/ZEzsjB97ynZgz1FaU4VdoZ1UxxVQIp47VnwaQ7h\nNRLhHOlYNZHrUT+bUwUhMcGPsR2K6d+R4J4iwGaLEhsjnUVr2Mgmq9cXotXeHWET\nhXmJkurAyCU7bC8sqeA6OllZt2rdxv0j8hfcejgzYO8SBOxN8mqnOO8ZAs75EPjK\nPVMqSAO5y2rYPfTBMgZmCkf7RZrmU1RL/be8/0WBipZcwGUVaNpQ27/sj9Uill/x\n2uTkckbDHHsIO9T2L6YT/Hl4ZzBRQwGUpRGRMRVYwNk0I7xTAgMBAAGjGDAWMBQG\nA1UdEQQNMAuCCWxvY2FsaG9zdDANBgkqhkiG9w0BAQsFAAOCAQEAY8PVKtHRFz8k\noQ+bvSDKcxivgWAzj+11BWcleazQCIDMLmCC9Fb8D9ElNQHaxM3IARbXHK5V7PYz\nZnWSzNMBIvALLd3t5OMUaP44k6CRvMssUJ2NTwdXi9L4pfYVA8HoC9Mu97R+vOIK\nTNC+1MnX7Xk+/OjVqgddi/Zo3QiBKJJ9PQz9uyYADKapMx3kTdgkmQEUp1eM0x2/\nkUeI8d+YyWLSRN6xg6JsQ+4Wu4igzZnUBrg4/+hnAeZkDn6Gr7wcF+7fi26zGNVi\nbtN627XEn8BYvBvg9eIKH9QUQ5bSIEklp/uDTw4XAFI+ulXcHbarF4skJFNAu+Q8\nyuEpkyskTA=\n-----END CERTIFICATE-----\n")
```

So change to this:

```
edgedb error: ClientError: cannot read credentials file C:\Users\mithr\AppData\Local\EdgeDB\config\credentials\anything.json: detected conflicting settings.
tls_ca =
Some(
    "-----BEGIN CERTIFICATE-----\nMIIC0zCCAbugAwIBAgIRAMFs6w0fiU2omuuhw9I7ew0wDQYJKoZIhvcNAQELBQAw\nGDEWMBQGA1UEAwwNRWRnZURCIFNlcnZlcjAeFw0yMzEwMjIxODM4MzNaFw00MjEy\nMjIxODM4MzNaMBgxFjAUBgNVBAMMDUVkZ2VEQiBTZXJ2ZXIwggEiMA0GCSqGSIb3\nDQEBAQUAA4IBDwAwggEKAoIBAQCPDnnf5mcSzOC8MQkGvhBSrBMuQRtCm/YPacLA\nX6zUqIYI9F3tjlcKRtM7Swt6/ZEzsjB97ynZgz1FaU4VdoZ1UxxVQIp47VnwaQ7h\nNRLhHOlYNZHrUT+bUwUhMcGPsR2K6d+R4J4iwGaLEhsjnUVr2Mgmq9cXotXeHWET\nhXmJkurAyCU7bC8sqeA6OllZt2rdxv0j8hfcejgzYO8SBOxN8mqnOO8ZAs75EPjK\nPVMqSAO5y2rYPfTBMgZmCkf7RZrmU1RL/be8/0WBipZcwGUVaNpQ27/sj9Uill/x\n2uTkckbDHHsIO9T2L6YT/Hl4ZzBRQwGUpRGRMRVYwNk0I7xTAgMBAAGjGDAWMBQG\nA1UdEQQNMAuCCWxvY2FsaG9zdDANBgkqhkiG9w0BAQsFAAOCAQEAY8PVKtHRFz8k\noQ+bvSDKcxivgWAzj+11BWcleazQCIDMLmCC9Fb8D9ElNQHaxM3IARbXHK5V7PYz\nZnWSzNMBIvALLd3t5OMUaP44k6CRvMssUJ2NTwdXi9L4pfYVA8HoC9Mu97R+vOIK\nTNC+1MnX7Xk+/OjVqgddi/Zo3QiBKJJ9PQz9uyYADKapMx3kTdgkmQEUp1eM0x2/\nkUeI8d+YyWLSRN6xg6JsQ+4Wu4igzZnUBrg4/+hnAeZkDn6Gr7wcF+7fi26zGNVi\nbtN627XEn8BYvBvg9eIKH9QUQ5bSIEklp/uDTw4XAFI+ulXcHbarF4skJFNAu+Q8\nyuEpkyskTA==\n-----END CERTIFICATE-----\n",
)
but tls_cert_data =
Some(
    "-----EGIN CERTIFICATE-----\nMIIC0zCCAbugAwIBAgIRAMFs6w0fiU2omuuhw9I7ew0wDQYJKoZIhvcNAQELBQAw\nGDEWMBQGA1UEAwwNRWRnZURCIFNlcnZlcjAeFw0yMzEwMjIxODM4MzNaFw00MjEy\nMjIxODM4MzNaMBgxFjAUBgNVBAMMDUVkZ2VEQiBTZXJ2ZXIwggEiMA0GCSqGSIb3\nDQEBAQUAA4IBDwAwggEKAoIBAQCPDnnf5mcSzOC8MQkGvhBSrBMuQRtCm/YPacLA\nX6zUqIYI9F3tjlcKRtM7Swt6/ZEzsjB97ynZgz1FaU4VdoZ1UxxVQIp47VnwaQ7h\nNRLhHOlYNZHrUT+bUwUhMcGPsR2K6d+R4J4iwGaLEhsjnUVr2Mgmq9cXotXeHWET\nhXmJkurAyCU7bC8sqeA6OllZt2rdxv0j8hfcejgzYO8SBOxN8mqnOO8ZAs75EPjK\nPVMqSAO5y2rYPfTBMgZmCkf7RZrmU1RL/be8/0WBipZcwGUVaNpQ27/sj9Uill/x\n2uTkckbDHHsIO9T2L6YT/Hl4ZzBRQwGUpRGRMRVYwNk0I7xTAgMBAAGjGDAWMBQG\nA1UdEQQNMAuCCWxvY2FsaG9zdDANBgkqhkiG9w0BAQsFAAOCAQEAY8PVKtHRFz8k\noQ+bvSDKcxivgWAzj+11BWcleazQCIDMLmCC9Fb8D9ElNQHaxM3IARbXHK5V7PYz\nZnWSzNMBIvALLd3t5OMUaP44k6CRvMssUJ2NTwdXi9L4pfYVA8HoC9Mu97R+vOIK\nTNC+1MnX7Xk+/OjVqgddi/Zo3QiBKJJ9PQz9uyYADKapMx3kTdgkmQEUp1eM0x2/\nkUeI8d+YyWLSRN6xg6JsQ+4Wu4igzZnUBrg4/+hnAeZkDn6Gr7wcF+7fi26zGNVi\nbtN627XEn8BYvBvg9eIKH9QUQ5bSIEklp/uDTw4XAFI+ulXcHbarF4skJFNAu+Q8\nyuEpkyskTA==\n-----END CERTIFICATE-----\n",
)
```