### PR TITLE
Add with-serde feature for (De)Serialize

### DIFF
--- a/edgedb-protocol/Cargo.toml
+++ b/edgedb-protocol/Cargo.toml
@@ -21,6 +21,7 @@ bigdecimal = {version="0.3.0", optional=true}
 chrono = {version="0.4.23", optional=true, features=["std"], default-features=false}
 edgedb-errors = {path = "../edgedb-errors", version = "0.4.0" }
 bitflags = "2.4.0"
+serde = {version="1.0.190", optional=true}
 
 [features]
 default = []
@@ -28,6 +29,7 @@ with-num-bigint = ["num-bigint", "num-traits"]
 with-bigdecimal = ["bigdecimal", "num-bigint", "num-traits"]
 with-chrono = ["chrono"]
 all-types = ["with-num-bigint", "with-bigdecimal", "with-chrono"]
+with-serde = ["serde"]
 
 [dev-dependencies]
 rand = "0.8"

--- a/edgedb-protocol/src/model/bignum.rs
+++ b/edgedb-protocol/src/model/bignum.rs
@@ -6,6 +6,7 @@ mod bigdecimal_interop;
 
 /// Virtually unlimited precision integer.
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BigInt {
     pub(crate) negative: bool,
     pub(crate) weight: i16,
@@ -14,6 +15,7 @@ pub struct BigInt {
 
 /// High-precision decimal number.
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Decimal {
     pub(crate) negative: bool,
     pub(crate) weight: i16,

--- a/edgedb-protocol/src/model/json.rs
+++ b/edgedb-protocol/src/model/json.rs
@@ -1,5 +1,6 @@
 /// A newtype for JSON received from the database
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Json(String);
 
 impl Json {

--- a/edgedb-protocol/src/model/memory.rs
+++ b/edgedb-protocol/src/model/memory.rs
@@ -2,6 +2,7 @@ use std::fmt::{Debug, Display};
 
 /// A type for cfg::memory received from the database
 #[derive(Copy, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigMemory(pub i64);
 
 impl ConfigMemory {}

--- a/edgedb-protocol/src/model/range.rs
+++ b/edgedb-protocol/src/model/range.rs
@@ -8,6 +8,7 @@ pub(crate) const UB_INF: usize = 0x10;
 
 
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Range<T> {
     pub(crate) lower: Option<T>,
     pub(crate) upper: Option<T>,

--- a/edgedb-protocol/src/model/time.rs
+++ b/edgedb-protocol/src/model/time.rs
@@ -8,18 +8,21 @@ use std::str::FromStr;
 ///
 /// Precision: microseconds.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Duration {
     pub(crate) micros: i64,
 }
 
 /// A combination [`LocalDate`] and [`LocalTime`].
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LocalDatetime {
     pub(crate) micros: i64,
 }
 
 /// Naive date without a timezone.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LocalDate {
     pub(crate) days: i32,
 }
@@ -30,18 +33,21 @@ pub struct LocalDate {
 ///
 /// Precision: microseconds.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LocalTime {
     pub(crate) micros: u64,
 }
 
 /// A UTC date and time.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Datetime {
     pub(crate) micros: i64,
 }
 
 /// A type that can represent a human-friendly duration like 1 month or two days.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RelativeDuration {
     pub(crate) micros: i64,
     pub(crate) days: i32,
@@ -50,6 +56,7 @@ pub struct RelativeDuration {
 
 /// A type that can represent a human-friendly date duration like 1 month or two days.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DateDuration {
     pub(crate) days: i32,
     pub(crate) months: i32,

--- a/edgedb-protocol/src/model/vector.rs
+++ b/edgedb-protocol/src/model/vector.rs
@@ -4,14 +4,15 @@ use bytes::Buf;
 use snafu::ensure;
 
 use crate::codec;
-use crate::descriptors::{TypePos};
+use crate::descriptors::TypePos;
 use crate::errors::{self, DecodeError};
-use crate::queryable::{DescriptorMismatch};
+use crate::queryable::DescriptorMismatch;
 use crate::queryable::{Queryable, Decoder, DescriptorContext};
 use crate::serialization::decode::queryable::scalars::check_scalar;
 
 /// A structure that represents `ext::pgvector::vector`
 #[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Vector(pub Vec<f32>);
 
 impl Deref for Vector {


### PR DESCRIPTION
Right now no user can create a struct or enum that implements Deserialize and/or Serialize and also holds one of the types inside edgedb_protocol::model. This crate seems meant to be as lean as possible with any extra interop with major Rust crates (chrono, bigint, etc.) gated behind feature flags so feels like a serde feature makes sense too.