### PR TITLE
Handle server v4.3 changes in answering UPDATE query

### DIFF
--- a/edgedb-protocol/Cargo.toml
+++ b/edgedb-protocol/Cargo.toml
@@ -22,6 +22,7 @@ chrono = {version="0.4.23", optional=true, features=["std"], default-features=fa
 edgedb-errors = {path = "../edgedb-errors", version = "0.4.0" }
 bitflags = "2.4.0"
 serde = {version="1.0.190", optional=true}
+log = "0.4.8"
 
 [features]
 default = []

--- a/edgedb-protocol/src/codec.rs
+++ b/edgedb-protocol/src/codec.rs
@@ -692,7 +692,7 @@ impl Codec for Object {
         );
         log::debug!(target: LOG_TARGET, "Server returned fields {:?}", fields);
         log::debug!(target: LOG_TARGET, "Our codecs: {:?}", self.codecs);
-        // In v4.3, because the server replied ObjectShape with different order of fields,
+        // In v4.3, because the server returns an ObjectShape with different order of fields,
         // we need to sort their fields to the same order as our codecs before encoding.
         let mut server_field_names: Vec<(&str, usize)> = shape
             .elements
@@ -708,7 +708,7 @@ impl Codec for Object {
             .map(|(i, e)| (e.name.as_str(), i))
             .collect();
         // Sort server-returned fields by our order
-        server_field_names.sort_unstable_by_key(|k| our_field_names.get(&k.0));
+        server_field_names.sort_unstable_by_key(|(k, _i)| our_field_names.get(k));
         // Map to translate original order to new order for a field
         let old_to_new_order_map: HashMap<usize, usize> = server_field_names
             .into_iter()

--- a/edgedb-protocol/src/codec.rs
+++ b/edgedb-protocol/src/codec.rs
@@ -709,6 +709,7 @@ impl Codec for Object {
             .collect();
         // Sort server-returned fields by our order
         server_field_names.sort_unstable_by_key(|k| our_field_names.get(&k.0));
+        // Map to translate original order to new order for a field
         let old_to_new_order_map: HashMap<usize, usize> = server_field_names
             .into_iter()
             .enumerate()
@@ -716,8 +717,6 @@ impl Codec for Object {
             .collect();
         let mut sorted_fields: Vec<(usize, &Option<Value>)> =
             fields.into_iter().enumerate().collect();
-        // let mut sorted_fields: Vec<(usize, Option<Value>)> =
-        //     fields.clone().into_iter().enumerate().collect();
         sorted_fields.sort_unstable_by_key(|(old_order, _v)| old_to_new_order_map.get(old_order));
         let sorted_fields: Vec<&Option<Value>> =
             sorted_fields.into_iter().map(|(_i, value)| value).collect();

--- a/edgedb-protocol/src/common.rs
+++ b/edgedb-protocol/src/common.rs
@@ -13,8 +13,7 @@ use crate::features::ProtocolVersion;
 
 pub use crate::client_message::IoFormat;
 
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Cardinality {
     NoResult = 0x6e,
     AtMostOne = 0x6f,
@@ -77,10 +76,7 @@ impl RawTypedesc {
         }
     }
     pub fn decode(&self) -> Result<Typedesc, DecodeError> {
-        let ref mut cur = Input::new(
-            self.proto.clone(),
-            self.data.clone(),
-        );
+        let ref mut cur = Input::new(self.proto.clone(), self.data.clone());
         Typedesc::decode_with_id(self.id, cur)
     }
 }


### PR DESCRIPTION
In v4.3, when we execute `UPDATE` query with named parameters (passed via `Value::Object`), the server answers `CommandDataDescription` with different order of object fields, that makes our client failed with `MismatchObjectShape`.

This PR is to let the client flexible with that.