### PR TITLE
disable autoformatting

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true


### PR DESCRIPTION
Thanks for all your hard work on EdgeDB!

It would reduce friction for potential contributors if IDE autoformatting did not need to be disabled to interact with the codebase. Based on #245, I have the impression that you would prefer not to use `rustfmt`. This PR would formally disable `rustfmt` so that contributors don't have to suppress formatting on save.

