### PR TITLE
fix(encode): compare shapes by sorted fields (credits to @hongquan)

### DIFF
--- a/edgedb-protocol/src/common.rs
+++ b/edgedb-protocol/src/common.rs
@@ -14,7 +14,7 @@ use crate::features::ProtocolVersion;
 pub use crate::client_message::IoFormat;
 
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Cardinality {
     NoResult = 0x6e,
     AtMostOne = 0x6f,


### PR DESCRIPTION
Problem:
```rust
use edgedb_protocol::{
   value::{EnumValue, Value as EValue},
};

let args = indexmap! {
   "me_num" => (Some(EValue::Int64(user.num)), Cd::One),
   "activities" => (Some(EValue::Array(vec![EValue::Enum(EnumValue::from("Freelancer"))])), Cd::AtMostOne)
};
let args = helpers::edge_object_from_pairs(m);

let q = "
   update User
   filter .num = <int64>$me_num
   set {
      activities := <optional array<Activity>>$activities ?? .activities,
   }
";
ctx.edb.execute(q, &args).await?;
```
Will fail with `ClientEncodingError` #298 
Discord thread will full problem description: https://discord.com/channels/841451783728529451/1216718781846392852

I rewrote solution of @hongquan (#289) without reformatting, so changes are more readable. 
We can discuss here more elegant solution
