### PR TITLE
Fix credentials reading

### DIFF
--- a/edgedb-tokio/src/builder.rs
+++ b/edgedb-tokio/src/builder.rs
@@ -1745,13 +1745,21 @@ impl Config {
                     be saved as credentials file"));
             }
         };
+
+        let branch = Some(&self.0.branch)
+            .filter(|x| x.as_str() != "__default__");
+
         Ok(Credentials {
             host: Some(host.clone()),
             port: *port,
             user: self.0.user.clone(),
             password: self.0.password.clone(),
-            database: if self.0.branch == "__default__" { Some(self.0.database.clone()) } else { None },
-            branch: if self.0.branch == "__default__" { None } else { Some(self.0.branch.clone()) },
+            branch: branch.cloned(),
+
+            // this is not strictly needed (it gets overwritten when reading),
+            // but we want to keep backward compatibility. If you downgrade CLI,
+            // we want it to be able to interact with the new format of credentials.
+            database: branch.cloned(),
             tls_ca: self.0.pem_certificates.clone(),
             tls_security: self.0.tls_security,
             file_outdated: false,

--- a/edgedb-tokio/src/builder.rs
+++ b/edgedb-tokio/src/builder.rs
@@ -1733,6 +1733,11 @@ impl Config {
         &self.0.database
     }
 
+    /// Database branch name
+    pub fn branch(&self) -> &str {
+        &self.0.branch
+    }
+
     /// Extract credentials from the [Builder] so they can be saved as JSON.
     pub fn as_credentials(&self) -> Result<Credentials, Error> {
         let (host, port) = match &self.0.address {

--- a/edgedb-tokio/src/builder.rs
+++ b/edgedb-tokio/src/builder.rs
@@ -556,7 +556,6 @@ impl<'a> DsnHelper<'a> {
         });
         self.retrieve_value("branch", v, |s| {
             let s = s.strip_prefix('/').unwrap_or(&s);
-            dbg!("here");
             validate_branch(&s)?;
             Ok(s.to_owned())
         }).await
@@ -703,7 +702,6 @@ impl Builder {
 
     /// Set the branch name.
     pub fn branch(&mut self, branch: &str) -> Result<&mut Self, Error> {
-        dbg!("here");
         validate_branch(branch)?;
         self.branch = Some(branch.into());
         Ok(self)

--- a/edgedb-tokio/src/client.rs
+++ b/edgedb-tokio/src/client.rs
@@ -251,7 +251,6 @@ impl Client {
             let data = match res {
                 Ok(data) => data,
                 Err(e) => {
-                    dbg!(&e, e.has_tag(SHOULD_RETRY));
                     if desc.capabilities == Capabilities::empty() &&
                         e.has_tag(SHOULD_RETRY)
                     {

--- a/edgedb-tokio/tests/func/server.rs
+++ b/edgedb-tokio/tests/func/server.rs
@@ -99,7 +99,6 @@ impl ServerGuard {
             .status()
             .expect("cannot run edgedb-cli to create a migration")
             .success());
-        dbg!("2");
         assert!(Command::new("edgedb")
             .current_dir("./tests/func")
             .arg("--tls-security")


### PR DESCRIPTION
When writing to `credentials.json` we now always use `branch` instead of `database` and don't write anything if `branch="__default__"`.

Behavior before was breaking when we linked a new instance without specifying a database or branch. It would write just `database="edgedb"` into credentials, which was then also used as `branch`.