### PR TITLE
Implement `From<model::*> for Value`

### DIFF
--- a/edgedb-protocol/src/value.rs
+++ b/edgedb-protocol/src/value.rs
@@ -197,3 +197,23 @@ impl From<f64> for Value {
         Value::Float64(num)
     }
 }
+
+macro_rules! implement_model_to_value {
+    ($t:ty) => {
+        impl From<$t> for Value {
+            fn from(model: $t) -> Value {
+                model.to_value().expect("failed to convert model to Value")
+            }
+        }
+    };
+}
+
+use crate::query_arg::ScalarArg;
+implement_model_to_value!(crate::model::BigInt);
+implement_model_to_value!(crate::model::Decimal);
+implement_model_to_value!(crate::model::Uuid);
+implement_model_to_value!(crate::model::Json);
+implement_model_to_value!(crate::model::Duration);
+implement_model_to_value!(crate::model::Datetime);
+implement_model_to_value!(crate::model::LocalDate);
+implement_model_to_value!(crate::model::LocalDatetime);

--- a/edgedb-protocol/src/value.rs
+++ b/edgedb-protocol/src/value.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 
 use crate::codec::{NamedTupleShape, ObjectShape, ShapeElement};
 use crate::common::Cardinality;
-use crate::model::{BigInt, Decimal, Uuid, ConfigMemory, Range};
+use crate::model::{BigInt, ConfigMemory, Decimal, Range, Uuid};
 use crate::model::{LocalDatetime, LocalDate, LocalTime, Duration, Datetime};
 use crate::model::{RelativeDuration, DateDuration, Json};
 pub use crate::codec::EnumValue;
@@ -198,22 +198,50 @@ impl From<f64> for Value {
     }
 }
 
-macro_rules! implement_model_to_value {
-    ($t:ty) => {
-        impl From<$t> for Value {
-            fn from(model: $t) -> Value {
-                model.to_value().expect("failed to convert model to Value")
-            }
-        }
-    };
+impl From<BigInt>for Value {
+    fn from(model: BigInt) -> Value {
+        Value::BigInt(model)
+    }
 }
 
-use crate::query_arg::ScalarArg;
-implement_model_to_value!(crate::model::BigInt);
-implement_model_to_value!(crate::model::Decimal);
-implement_model_to_value!(crate::model::Uuid);
-implement_model_to_value!(crate::model::Json);
-implement_model_to_value!(crate::model::Duration);
-implement_model_to_value!(crate::model::Datetime);
-implement_model_to_value!(crate::model::LocalDate);
-implement_model_to_value!(crate::model::LocalDatetime);
+impl From<Decimal> for Value {
+    fn from(v: Decimal) -> Value {
+        Value::Decimal(v)
+    }
+}
+
+impl From<Uuid> for Value {
+    fn from(v: Uuid) -> Value {
+        Value::Uuid(v)
+    }
+}
+
+impl From<Json> for Value {
+    fn from(v: Json) -> Value {
+        Value::Json(v)
+    }
+}
+
+impl From<Duration> for Value {
+    fn from(v: Duration) -> Value {
+        Value::Duration(v)
+    }
+}
+
+impl From<Datetime> for Value {
+    fn from(v: Datetime) -> Value {
+        Value::Datetime(v)
+    }
+}
+
+impl From<LocalDate> for Value {
+    fn from(v: LocalDate) -> Value {
+        Value::LocalDate(v)
+    }
+}
+
+impl From<LocalDatetime> for Value {
+    fn from(v: LocalDatetime) -> Value {
+        Value::LocalDatetime(v)
+    }
+}

--- a/edgedb-tokio/tests/func/client.rs
+++ b/edgedb-tokio/tests/func/client.rs
@@ -1,3 +1,6 @@
+use std::str::FromStr;
+
+use edgedb_protocol::model::Uuid;
 use edgedb_protocol::named_args;
 use edgedb_protocol::value::{EnumValue, Value};
 use edgedb_tokio::Client;
@@ -86,6 +89,16 @@ async fn simple() -> anyhow::Result<()> {
         }
     ).await.unwrap();
     assert_eq!(value.as_str(), "the answer to the ultimate question of life: 42");
+
+    // args for values
+    let uuid = "43299d0a-f993-4dcb-a8a2-50041bf5af79";
+    let value = client.query_required_single::<Uuid, _>(
+        "select <uuid>$my_uuid;",
+        &named_args! {
+            "my_uuid" => Uuid::from_str("43299d0a-f993-4dcb-a8a2-50041bf5af79").unwrap(),
+        }
+    ).await.unwrap();
+    assert_eq!(value, Uuid::from_str(uuid).unwrap());
 
     Ok(())
 }


### PR DESCRIPTION
So instead of
```rs
let args = named_args! {
   "id" => edb_model::Uuid::from_str(&otp_request.id)?.to_value()?,
   "confirmed_at" => edb_model::Datetime::try_from(Utc::now())?.to_value()?
};
```
we will write
```rs
let args = named_args! {
   "id" => edb_model::Uuid::from_str(&otp_request.id)?,
   "confirmed_at" => edb_model::Datetime::try_from(Utc::now())?
};
```

Note: I'm using `.expect()` and not try_from because as I saw all `to_value` implementations do not fail at all