### PR TITLE
When starting edgedb-server for tests, log to a file instead of the terminal

### DIFF
--- a/edgedb-tokio/tests/func/server.rs
+++ b/edgedb-tokio/tests/func/server.rs
@@ -171,7 +171,7 @@ fn write_log_into_file(stream: impl std::io::Read) {
     eprintln!("Writing server logs into {:?}", &log_file);
 
     std::fs::create_dir_all(&log_dir).unwrap();
-    let mut log_file = File::create_new(log_file).unwrap();
+    let mut log_file = File::create(log_file).unwrap();
 
     let mut reader = BufReader::new(stream);
     std::io::copy(&mut reader, &mut log_file).unwrap();


### PR DESCRIPTION
Long-term, I think that this piece of code that starts the edgedb-server should be:
- improved so it is easier to debug what's going wrong when it failes,
- moved to a separate crate so it can be reused in the CLI