### PR TITLE
encode missing entry as `None`

### DIFF
--- a/edgedb-protocol/src/value_opt.rs
+++ b/edgedb-protocol/src/value_opt.rs
@@ -77,6 +77,11 @@ impl QueryArgs for HashMap<&str, ValueOpt> {
             let value = self.get(param_descriptor.name.as_str());
 
             let Some(value) = value else {
+                if param_descriptor.cardinality.is_some_and(|cardinality| cardinality.is_optional()) {
+                    shape_elements.push(ShapeElement::from(param_descriptor));
+                    fields.push(None);
+                    continue;
+                }
                 return Err(ClientEncodingError::with_message(format!(
                     "argument for ${} missing",
                     param_descriptor.name

--- a/edgedb-tokio/tests/func/client.rs
+++ b/edgedb-tokio/tests/func/client.rs
@@ -82,6 +82,7 @@ async fn simple() -> anyhow::Result<()> {
             ++ (<optional str>$question ?? ' the ultimate question of life')
             ++ ': '
             ++ <str><int64>$answer
+            ++ <optional str>$not_an_answer
         );",
         &named_args! {
             "msg1" => vec!["the".to_string(), "answer".to_string(), "to".to_string()],
@@ -147,7 +148,7 @@ async fn json() -> anyhow::Result<()> {
        pub phone: String,
        pub otp: i32,
     }
-    
+
     let res = client.query::<OtpPhoneRequest, _>(
         "select <json>(select test::OtpPhoneRequest { phone, otp } filter .phone = '0123456789')",
         &()


### PR DESCRIPTION
Otherwise we need to specify every `None` entry explicitly. I think this is not very convinent and also it doesn't align with javascript client behaviour