### PR TITLE
Custom error type in transactions

### DIFF
--- a/edgedb-tokio/src/lib.rs
+++ b/edgedb-tokio/src/lib.rs
@@ -139,6 +139,7 @@ mod transaction;
 pub mod tutorial;
 
 pub use edgedb_derive::{ConfigDelta, GlobalsDelta, Queryable};
+pub use transaction::EdgeDBErrorRef;
 
 pub use builder::{Builder, ClientSecurity, Config, InstanceName};
 pub use client::Client;

--- a/edgedb-tokio/src/transaction.rs
+++ b/edgedb-tokio/src/transaction.rs
@@ -64,6 +64,12 @@ impl EdgeDBErrorRef for Error {
     }
 }
 
+impl EdgeDBErrorRef for anyhow::Error {
+    fn as_edgedb_error_ref(&self) -> Option<&Error> {
+        self.downcast_ref::<Error>()
+    }
+}
+
 pub(crate) async fn transaction<T, B, F, E>(
     pool: &Pool,
     options: &Options,


### PR DESCRIPTION
In production we write quite a bit of code inside of EdgeDB Transactions, however the limitation of having to return an `edgedb_tokio::Error` is starting to weigh down on us as we don't want to convert them all to the same error type and then afterwards to cast them back to the correct type.

I introduced the new function `transaction_with_err` that allows the closure to return any error type as long as it:
- can be turned into `edgedb_tokio::Error`
- if it wraps a `edgedb_tokio::Error` inside (since we want to mix application code into the transaction), it returns a `Option<&Error>` ref to it, this is expressed through the `EdgeDBErrorRef` trait.

Here an example how you could use this:
```rust
 #[derive(thiserror::Error, Debug)]
 enum MyError {
     #[error(transparent)]
     EdgeDBError(#[from] edgedb_tokio::Error),
     #[error("Something went wrong and it wasn't EdgeDB")]
     SomethingWentWrong,
 }

 impl EdgeDBErrorRef for MyError {
     fn as_edge_db_error(&self) -> Option<&edgedb_tokio::Error> {
         match self {
             MyError::EdgeDBError(e) => Some(e),
             _ => None,
         }
     }
 }

 let conn = edgedb_tokio::create_client().await?;
 let val = conn.transaction_with_err::<_, _, _, MyError>(|mut tx| async move {
     tx.query_required_single::<i64, _>("
         WITH C := UPDATE Counter SET { value := .value + 1}
         SELECT C.value LIMIT 1
     ", &()
     ).await
}).await?;
  ```
  Implementations for `EdgeDBErrorRef` for `anyhow::Error` and `edgedb_tokio::Error` are provided out of the box.
  
  Let me know what you think of this idea!
