### PR TITLE
Set keep-alive on TCP sockets

### DIFF
--- a/edgedb-tokio/Cargo.toml
+++ b/edgedb-tokio/Cargo.toml
@@ -50,6 +50,7 @@ once_cell = "1.9.0"
 tokio-stream = { version = "0.1.11", optional = true }
 base64 = "0.22.1"
 crc16 = "0.4.0"
+socket2 = "0.5"
 
 [target.'cfg(target_family="unix")'.dev-dependencies]
 command-fds = "0.3.0"

--- a/edgedb-tokio/src/builder.rs
+++ b/edgedb-tokio/src/builder.rs
@@ -63,10 +63,14 @@ pub enum CloudCerts {
     Local,
 }
 
+/// TCP keepalive configuration.
 #[derive(Default, Debug, Clone, Copy)]
 pub enum TcpKeepalive {
+    /// Disable TCP keepalive probes.
     Disabled,
+    /// Explicit duration between TCP keepalive probes.
     Explicit(Duration),
+    /// Default: 60 seconds.
     #[default]
     Default,
 }
@@ -809,10 +813,11 @@ impl Builder {
         self
     }
 
-    /// Sets the TCP keepalive interval for the database connection to ensure
-    /// that the remote end of the connection is still alive, and to inform any
-    /// network intermediaries that this connection is not idle. By default, a
-    /// keepalive probe will be sent once every 60 seconds.
+    /// Sets the TCP keepalive interval and time for the database connection to
+    /// ensure that the remote end of the connection is still alive, and to
+    /// inform any network intermediaries that this connection is not idle. By
+    /// default, a keepalive probe will be sent once every 60 seconds once the
+    /// connection has been idle for 60 seconds.
     ///
     /// Note: If the connection is not made over a TCP socket, this value will
     /// be unused. If the current platform does not support explicit TCP

--- a/edgedb-tokio/src/builder.rs
+++ b/edgedb-tokio/src/builder.rs
@@ -809,6 +809,20 @@ impl Builder {
         self
     }
 
+    /// Sets the TCP keepalive interval for the database connection to ensure
+    /// that the remote end of the connection is still alive, and to inform any
+    /// network intermediaries that this connection is not idle. By default, a
+    /// keepalive probe will be sent once every 60 seconds.
+    ///
+    /// Note: If the connection is not made over a TCP socket, this value will
+    /// be unused. If the current platform does not support explicit TCP
+    /// keep-alive intervals on the socket, keepalives will be enabled and the
+    /// operating-system default for the intervals will be used.
+    pub fn tcp_keepalive(&mut self, tcp_keepalive: TcpKeepalive) -> &mut Self {
+        self.tcp_keepalive = Some(tcp_keepalive);
+        self
+    }
+
     /// Set the maximum number of underlying database connections.
     pub fn max_concurrency(&mut self, value: usize) -> &mut Self {
         self.max_concurrency = Some(value);
@@ -899,11 +913,11 @@ impl Builder {
 
             // Temporary placeholders
             verifier: Arc::new(tls::NullVerifier),
-            client_security: self.client_security.unwrap_or(ClientSecurity::Default),
+            client_security: self.client_security.unwrap_or_default(),
             tls_security: self
                 .tls_security
                 .or_else(|| creds.map(|c| c.tls_security))
-                .unwrap_or(TlsSecurity::Default),
+                .unwrap_or_default(),
         };
 
         cfg.verifier = cfg.make_verifier(cfg.compute_tls_security()?);
@@ -1528,8 +1542,8 @@ impl Builder {
             extra_dsn_query_args: HashMap::new(),
             creds_file_outdated: false,
             pem_certificates: self.pem_certificates.clone(),
-            client_security: self.client_security.unwrap_or(ClientSecurity::Default),
-            tls_security: self.tls_security.unwrap_or(TlsSecurity::Default),
+            client_security: self.client_security.unwrap_or_default(),
+            tls_security: self.tls_security.unwrap_or_default(),
             tcp_keepalive: self.tcp_keepalive.unwrap_or_default().as_keepalive(),
             // Pool configuration
             max_concurrency: self.max_concurrency,

--- a/edgedb-tokio/src/credentials.rs
+++ b/edgedb-tokio/src/credentials.rs
@@ -1,13 +1,13 @@
 //! Credentials file handling routines
-use std::fmt;
 use std::str::FromStr;
+use std::{default, fmt};
 
 use serde::{ser, Deserialize, Serialize};
 
 use crate::errors::{Error, ErrorKind};
 
 /// TLS Client Security Mode
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TlsSecurity {
     /// Allow any certificate for TLS connection
@@ -23,6 +23,7 @@ pub enum TlsSecurity {
     Strict,
     /// If there is a specific certificate in credentials, do not check
     /// the host name, otherwise use `Strict` mode
+    #[default]
     Default,
 }
 

--- a/edgedb-tokio/src/credentials.rs
+++ b/edgedb-tokio/src/credentials.rs
@@ -1,6 +1,6 @@
 //! Credentials file handling routines
+use std::fmt;
 use std::str::FromStr;
-use std::{default, fmt};
 
 use serde::{ser, Deserialize, Serialize};
 

--- a/edgedb-tokio/src/lib.rs
+++ b/edgedb-tokio/src/lib.rs
@@ -140,7 +140,7 @@ pub mod tutorial;
 
 pub use edgedb_derive::{ConfigDelta, GlobalsDelta, Queryable};
 
-pub use builder::{Builder, ClientSecurity, Config, InstanceName};
+pub use builder::{Builder, ClientSecurity, Config, InstanceName, TcpKeepalive};
 pub use client::Client;
 pub use credentials::TlsSecurity;
 pub use errors::Error;

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,7 @@
             buildInputs = [
               (fenix_pkgs.toolchainOf {
                 channel = "beta";
-                sha256 = "sha256-H1BZtppFoMkxdDQ6ZVbTSg9PoKzkvsEbSSPIoB55t1w=";
+                sha256 = "sha256-WtTNSmxfoiHJEwCUnuDNfRNBZjNrzdBV02Hikw+YE+s=";
               }).defaultToolchain
             ] ++ common;
           };


### PR DESCRIPTION
Migrations and other long-running operations may leave a TCP connection active but without any traffic. 

To prevent the operating systems on either end from closing the connections (or any other system that monitors for activity on TCP streams to determine when they should be closed), we can set the keep-alive flag on the client.

TODO:
 - [x] Add config parameter
