### PR TITLE
Minor maintenance work

### DIFF
--- a/edgedb-tokio/Cargo.toml
+++ b/edgedb-tokio/Cargo.toml
@@ -56,7 +56,6 @@ socket2 = "0.5"
 command-fds = "0.3.0"
 
 [dev-dependencies]
-nix = "0.28.0"
 shutdown_hooks = "0.1.0"
 env_logger = "0.11"
 thiserror = "1.0.30"

--- a/edgedb-tokio/src/builder.rs
+++ b/edgedb-tokio/src/builder.rs
@@ -846,7 +846,7 @@ impl Builder {
     /// 1. [`Builder::credentials_file()`] is not supported
     /// 2. [`Builder::dsn()`] is not supported yet (although, will be
     ///    implemented later restricing `*_file` and `*_env` query args
-    #[cfg(any(feature = "unstable", feature = "test"))]
+    #[cfg(any(feature = "unstable", test))]
     pub fn constrained_build(&self) -> Result<Config, Error> {
         let address = if let Some(unix_path) = &self.unix_path {
             let port = self.port.unwrap_or(DEFAULT_PORT);
@@ -1522,7 +1522,7 @@ impl Builder {
     ///
     /// First boolean item in the tuple is `true` if configuration is complete
     /// and can be used for connections.
-    #[cfg(any(feature = "unstable", feature = "test"))]
+    #[cfg(any(feature = "unstable", test))]
     pub async fn build_no_fail(&self) -> (bool, Config, Vec<Error>) {
         self._build_no_fail().await
     }
@@ -1998,14 +1998,14 @@ impl Config {
     }
 
     /// Return the same config with changed wait until available timeout
-    #[cfg(any(feature = "unstable", feature = "test"))]
+    #[cfg(any(feature = "unstable", test))]
     pub fn with_wait_until_available(mut self, wait: Duration) -> Config {
         Arc::make_mut(&mut self.0).wait = wait;
         self
     }
 
     /// Return the same config with changed certificates
-    #[cfg(any(feature = "unstable", feature = "test"))]
+    #[cfg(any(feature = "unstable", test))]
     pub fn with_pem_certificates(mut self, pem: &str) -> Result<Config, Error> {
         validate_certs(pem).context("invalid PEM certificate")?;
         let cfg = Arc::make_mut(&mut self.0);
@@ -2021,13 +2021,13 @@ impl Config {
     }
 
     /// Returns true if credentials file is in outdated format
-    #[cfg(any(feature = "unstable", feature = "test"))]
+    #[cfg(any(feature = "unstable", test))]
     pub fn is_creds_file_outdated(&self) -> bool {
         self.0.creds_file_outdated
     }
 
     /// Return the certificate store of the config
-    #[cfg(any(feature = "unstable", feature = "test"))]
+    #[cfg(any(feature = "unstable", test))]
     pub fn root_cert_store(&self) -> Result<rustls::RootCertStore, Error> {
         Ok(self.0.root_cert_store())
     }
@@ -2035,7 +2035,7 @@ impl Config {
     /// Return the same config with changed certificate verifier
     ///
     /// Command-line tool uses this for interactive verifier
-    #[cfg(any(feature = "unstable", feature = "test"))]
+    #[cfg(any(feature = "unstable", test))]
     pub fn with_cert_verifier(mut self, verifier: Verifier) -> Config {
         Arc::make_mut(&mut self.0).verifier = verifier;
         self

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715265269,
-        "narHash": "sha256-X/iFHrVS2Tr/3lwZmFRclDoaZxcKMGdpNfT49CZugaU=",
+        "lastModified": 1720422321,
+        "narHash": "sha256-6AOBQSP17xz0JjE5pI/ao/cFhMw6CiWJIE0NfxmAm34=",
         "owner": "edgedb",
         "repo": "packages-nix",
-        "rev": "0cc15a37b8430d0d5dafbbe6d9171df6d1ff0658",
+        "rev": "ec9d4c9bbde1e95e5b087163e96ceb707b485530",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1715063087,
-        "narHash": "sha256-cktPkcCmJ2sR0V/FaWEuCWmKuGPbwoMltih/EfF0mXg=",
+        "lastModified": 1723012113,
+        "narHash": "sha256-AJGsmwDnheWMjZWUqgiGtBjbxMmvLvMp5WJhmTRhJ4w=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "f8f16c1f2c83bea4e51e6522d988ec8bfcc8420e",
+        "rev": "3dab4ada5b0c5a22d56dbfd7e140c16f3df2e69a",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1714641030,
-        "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
         "type": "github"
       },
       "original": {
@@ -89,11 +89,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715184436,
-        "narHash": "sha256-GySDOHwaApTZWH9NId9cy3Dq+1mVzMOaE8qWMVwP+J4=",
+        "lastModified": 1723031421,
+        "narHash": "sha256-Q4iMzihS+4mzCadp+ADr782Jrd1Mgvr7lLZbkWx33Hw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4f554f0ff09c4cd34ca201c759c29008d1010eac",
+        "rev": "1602c0d3c0247d23eb7ca501c3e592aa1762e37b",
         "type": "github"
       },
       "original": {
@@ -104,14 +104,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1714640452,
-        "narHash": "sha256-QBx10+k6JWz6u7VsohfSw8g8hjdBZEf8CFzXH1/1Z94=",
+        "lastModified": 1722555339,
+        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
             buildInputs = [
               (fenix_pkgs.fromToolchainFile {
                 file = ./rust-toolchain.toml;
-                sha256 = "sha256-opUgs6ckUQCyDxcB9Wy51pqhd0MPGHUVbwRKKPGiwZU=";
+                sha256 = "sha256-6eN/GKzjVSjEhGO9FhWObkRFaE1Jf+uqMSdQnb8lcB4=";
               })
             ] ++ common;
           };
@@ -63,10 +63,7 @@
           # rust beta version
           devShells.beta = pkgs.mkShell {
             buildInputs = [
-              (fenix_pkgs.toolchainOf {
-                channel = "beta";
-                sha256 = "sha256-q7N1YC9mppPme25wjb81cuOgDXFCkA10Lb1D1GCDv04=";
-              }).defaultToolchain
+              fenix_pkgs.beta.defaultToolchain
             ] ++ common;
           };
         };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.78"
+channel = "1.80"
 components = ["rustc", "cargo", "rust-std", "rust-src", "clippy", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
- remove unused dev-dep on `nix`,
- update rust-toolchain.toml,
- update nix dev environments,
- apply a new clippy lints, which fixes a problem of a plain `cargo test`.