### PR TITLE
Add QueryExecutor trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ debug = true
 lto = true
 
 [workspace.package]
-rust-version = "1.72" # keep in sync with flake.nix
+rust-version = "1.75" # keep in sync with flake.nix
 
 [workspace.lints.clippy]
 useless_format = 'allow'

--- a/edgedb-tokio/src/lib.rs
+++ b/edgedb-tokio/src/lib.rs
@@ -133,11 +133,11 @@ mod builder;
 mod client;
 mod errors;
 mod options;
+mod query_executor;
 mod sealed;
 pub mod state;
 mod transaction;
 pub mod tutorial;
-mod query_executor;
 
 pub use edgedb_derive::{ConfigDelta, GlobalsDelta, Queryable};
 
@@ -146,9 +146,9 @@ pub use client::Client;
 pub use credentials::TlsSecurity;
 pub use errors::Error;
 pub use options::{RetryCondition, RetryOptions, TransactionOptions};
+pub use query_executor::QueryExecutor;
 pub use state::{ConfigDelta, GlobalsDelta};
 pub use transaction::Transaction;
-pub use query_executor::QueryExecutor;
 
 #[cfg(feature = "unstable")]
 pub use builder::get_project_dir;

--- a/edgedb-tokio/src/lib.rs
+++ b/edgedb-tokio/src/lib.rs
@@ -137,6 +137,7 @@ mod sealed;
 pub mod state;
 mod transaction;
 pub mod tutorial;
+mod query_executor;
 
 pub use edgedb_derive::{ConfigDelta, GlobalsDelta, Queryable};
 
@@ -147,6 +148,7 @@ pub use errors::Error;
 pub use options::{RetryCondition, RetryOptions, TransactionOptions};
 pub use state::{ConfigDelta, GlobalsDelta};
 pub use transaction::Transaction;
+pub use query_executor::QueryExecutor;
 
 #[cfg(feature = "unstable")]
 pub use builder::get_project_dir;

--- a/edgedb-tokio/src/query_executor.rs
+++ b/edgedb-tokio/src/query_executor.rs
@@ -9,7 +9,11 @@ use crate::{Client, Error, Transaction};
 /// In particular &Client and &mut Transaction
 pub trait QueryExecutor {
     /// see [Client::query]
-    fn query<R, A>(self, query: &str, arguments: &A) -> impl Future<Output = Result<Vec<R>, Error>> + Send
+    fn query<R, A>(
+        self,
+        query: &str,
+        arguments: &A,
+    ) -> impl Future<Output = Result<Vec<R>, Error>> + Send
     where
         A: QueryArgs,
         R: QueryResult + Send;
@@ -56,7 +60,11 @@ pub trait QueryExecutor {
     ) -> impl Future<Output = Result<Json, Error>>;
 
     /// see [Client::execute]
-    fn execute<A>(&mut self, query: &str, arguments: &A) -> impl Future<Output = Result<(), Error>> + Send
+    fn execute<A>(
+        &mut self,
+        query: &str,
+        arguments: &A,
+    ) -> impl Future<Output = Result<(), Error>> + Send
     where
         A: QueryArgs;
 }

--- a/edgedb-tokio/src/query_executor.rs
+++ b/edgedb-tokio/src/query_executor.rs
@@ -9,44 +9,44 @@ use crate::{Client, Error, Transaction};
 /// In particular &Client and &mut Transaction
 pub trait QueryExecutor {
     /// see [Client::query]
-    fn query<R, A>(self, query: &str, arguments: &A) -> impl Future<Output = Result<Vec<R>, Error>>
+    fn query<R, A>(self, query: &str, arguments: &A) -> impl Future<Output = Result<Vec<R>, Error>> + Send
     where
         A: QueryArgs,
-        R: QueryResult;
+        R: QueryResult + Send;
 
     /// see [Client::query_single]
     fn query_single<R, A>(
         self,
         query: &str,
         arguments: &A,
-    ) -> impl Future<Output = Result<Option<R>, Error>>
+    ) -> impl Future<Output = Result<Option<R>, Error>> + Send
     where
         A: QueryArgs,
-        R: QueryResult;
+        R: QueryResult + Send;
 
     /// see [Client::query_required_single]
     fn query_required_single<R, A>(
         self,
         query: &str,
         arguments: &A,
-    ) -> impl Future<Output = Result<R, Error>>
+    ) -> impl Future<Output = Result<R, Error>> + Send
     where
         A: QueryArgs,
-        R: QueryResult;
+        R: QueryResult + Send;
 
     /// see [Client::query_json]
     fn query_json(
         self,
         query: &str,
         arguments: &impl QueryArgs,
-    ) -> impl Future<Output = Result<Json, Error>>;
+    ) -> impl Future<Output = Result<Json, Error>> + Send;
 
     /// see [Client::query_single_json]
     fn query_single_json(
         &mut self,
         query: &str,
         arguments: &impl QueryArgs,
-    ) -> impl Future<Output = Result<Option<Json>, Error>>;
+    ) -> impl Future<Output = Result<Option<Json>, Error>> + Send;
 
     /// see [Client::query_required_single_json]
     fn query_required_single_json(
@@ -56,7 +56,7 @@ pub trait QueryExecutor {
     ) -> impl Future<Output = Result<Json, Error>>;
 
     /// see [Client::execute]
-    fn execute<A>(&mut self, query: &str, arguments: &A) -> impl Future<Output = Result<(), Error>>
+    fn execute<A>(&mut self, query: &str, arguments: &A) -> impl Future<Output = Result<(), Error>> + Send
     where
         A: QueryArgs;
 }
@@ -77,7 +77,7 @@ impl QueryExecutor for &Client {
     ) -> impl Future<Output = Result<Option<R>, Error>>
     where
         A: QueryArgs,
-        R: QueryResult,
+        R: QueryResult + Send,
     {
         Client::query_single(self, query, arguments)
     }
@@ -86,10 +86,10 @@ impl QueryExecutor for &Client {
         self,
         query: &str,
         arguments: &A,
-    ) -> impl Future<Output = Result<R, Error>>
+    ) -> impl Future<Output = Result<R, Error>> + Send
     where
         A: QueryArgs,
-        R: QueryResult,
+        R: QueryResult + Send,
     {
         Client::query_required_single(self, query, arguments)
     }

--- a/edgedb-tokio/src/query_executor.rs
+++ b/edgedb-tokio/src/query_executor.rs
@@ -1,0 +1,192 @@
+use edgedb_protocol::model::Json;
+use edgedb_protocol::query_arg::QueryArgs;
+use edgedb_protocol::QueryResult;
+use std::future::Future;
+
+use crate::{Client, Error, Transaction};
+
+/// Abstracts over different query executors
+/// In particular &Client and &mut Transaction
+pub trait QueryExecutor {
+    /// see [Client::query]
+    fn query<R, A>(self, query: &str, arguments: &A) -> impl Future<Output = Result<Vec<R>, Error>>
+    where
+        A: QueryArgs,
+        R: QueryResult;
+
+    /// see [Client::query_single]
+    fn query_single<R, A>(
+        self,
+        query: &str,
+        arguments: &A,
+    ) -> impl Future<Output = Result<Option<R>, Error>>
+    where
+        A: QueryArgs,
+        R: QueryResult;
+
+    /// see [Client::query_required_single]
+    fn query_required_single<R, A>(
+        self,
+        query: &str,
+        arguments: &A,
+    ) -> impl Future<Output = Result<R, Error>>
+    where
+        A: QueryArgs,
+        R: QueryResult;
+
+    /// see [Client::query_json]
+    fn query_json(
+        self,
+        query: &str,
+        arguments: &impl QueryArgs,
+    ) -> impl Future<Output = Result<Json, Error>>;
+
+    /// see [Client::query_single_json]
+    fn query_single_json(
+        &mut self,
+        query: &str,
+        arguments: &impl QueryArgs,
+    ) -> impl Future<Output = Result<Option<Json>, Error>>;
+
+    /// see [Client::query_required_single_json]
+    fn query_required_single_json(
+        &mut self,
+        query: &str,
+        arguments: &impl QueryArgs,
+    ) -> impl Future<Output = Result<Json, Error>>;
+
+    /// see [Client::execute]
+    fn execute<A>(&mut self, query: &str, arguments: &A) -> impl Future<Output = Result<(), Error>>
+    where
+        A: QueryArgs;
+}
+
+impl QueryExecutor for &Client {
+    fn query<R, A>(self, query: &str, arguments: &A) -> impl Future<Output = Result<Vec<R>, Error>>
+    where
+        A: QueryArgs,
+        R: QueryResult,
+    {
+        Client::query(self, query, arguments)
+    }
+
+    fn query_single<R, A>(
+        self,
+        query: &str,
+        arguments: &A,
+    ) -> impl Future<Output = Result<Option<R>, Error>>
+    where
+        A: QueryArgs,
+        R: QueryResult,
+    {
+        Client::query_single(self, query, arguments)
+    }
+
+    fn query_required_single<R, A>(
+        self,
+        query: &str,
+        arguments: &A,
+    ) -> impl Future<Output = Result<R, Error>>
+    where
+        A: QueryArgs,
+        R: QueryResult,
+    {
+        Client::query_required_single(self, query, arguments)
+    }
+
+    fn query_json(
+        self,
+        query: &str,
+        arguments: &impl QueryArgs,
+    ) -> impl Future<Output = Result<Json, Error>> {
+        Client::query_json(self, query, arguments)
+    }
+
+    fn query_single_json(
+        &mut self,
+        query: &str,
+        arguments: &impl QueryArgs,
+    ) -> impl Future<Output = Result<Option<Json>, Error>> {
+        Client::query_single_json(self, query, arguments)
+    }
+
+    fn query_required_single_json(
+        &mut self,
+        query: &str,
+        arguments: &impl QueryArgs,
+    ) -> impl Future<Output = Result<Json, Error>> {
+        Client::query_required_single_json(self, query, arguments)
+    }
+
+    fn execute<A>(&mut self, query: &str, arguments: &A) -> impl Future<Output = Result<(), Error>>
+    where
+        A: QueryArgs,
+    {
+        Client::execute(self, query, arguments)
+    }
+}
+
+impl QueryExecutor for &mut Transaction {
+    fn query<R, A>(self, query: &str, arguments: &A) -> impl Future<Output = Result<Vec<R>, Error>>
+    where
+        A: QueryArgs,
+        R: QueryResult,
+    {
+        Transaction::query(self, query, arguments)
+    }
+
+    fn query_single<R, A>(
+        self,
+        query: &str,
+        arguments: &A,
+    ) -> impl Future<Output = Result<Option<R>, Error>>
+    where
+        A: QueryArgs,
+        R: QueryResult,
+    {
+        Transaction::query_single(self, query, arguments)
+    }
+
+    fn query_required_single<R, A>(
+        self,
+        query: &str,
+        arguments: &A,
+    ) -> impl Future<Output = Result<R, Error>>
+    where
+        A: QueryArgs,
+        R: QueryResult,
+    {
+        Transaction::query_required_single(self, query, arguments)
+    }
+
+    fn query_json(
+        self,
+        query: &str,
+        arguments: &impl QueryArgs,
+    ) -> impl Future<Output = Result<Json, Error>> {
+        Transaction::query_json(self, query, arguments)
+    }
+
+    fn query_single_json(
+        &mut self,
+        query: &str,
+        arguments: &impl QueryArgs,
+    ) -> impl Future<Output = Result<Option<Json>, Error>> {
+        Transaction::query_single_json(self, query, arguments)
+    }
+
+    fn query_required_single_json(
+        &mut self,
+        query: &str,
+        arguments: &impl QueryArgs,
+    ) -> impl Future<Output = Result<Json, Error>> {
+        Transaction::query_required_single_json(self, query, arguments)
+    }
+
+    fn execute<A>(&mut self, query: &str, arguments: &A) -> impl Future<Output = Result<(), Error>>
+    where
+        A: QueryArgs,
+    {
+        Transaction::execute(self, query, arguments)
+    }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -54,8 +54,8 @@
           devShells.minimum = pkgs.mkShell {
             buildInputs = [
               (fenix_pkgs.toolchainOf {
-                channel = "1.72"; # keep in sync with ./Cargo.toml rust-version
-                sha256 = "sha256-dxE7lmCFWlq0nl/wKcmYvpP9zqQbBitAQgZ1zx9Ooik=";
+                channel = "1.75"; # keep in sync with ./Cargo.toml rust-version
+                sha256 = "sha256-SXRtAuO4IqNOQq+nLbrsDFbVk+3aVA8NNpSZsKlVH/8=";
               }).defaultToolchain
             ] ++ common;
           };


### PR DESCRIPTION
The trait enables writing functions that don't care if they're executed in a transaction or directly on a client.

Handling of `Send` needs to be discussed. Currently I'm not constraining anything to `Send`, but perhaps the returned futures need to be, but that might require adding constraints to some of the generic arguments (e.g. `QueryResult`) as well.

Closes #339