### PR TITLE
Allow cloud instance names to contain '-' and '_' in the org part to support vercel instances

### DIFF
--- a/edgedb-tokio/src/builder.rs
+++ b/edgedb-tokio/src/builder.rs
@@ -328,12 +328,12 @@ fn is_valid_local_instance_name(name: &str) -> bool {
 
 fn is_valid_cloud_name(name: &str) -> bool {
     // For cloud instance name parts (organization slugs and instance names):
-    //  1. Allow only letters, numbers and single dashes
-    //  2. Must not start or end with a dash
-    // regex: ^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$
+    //  1. Allow only letters, numbers, underscores and single dashes
+    //  2. Must not end with a dash
+    // regex: ^-?[a-zA-Z0-9_]+(-[a-zA-Z0-9]+)*$
     let mut chars = name.chars();
     match chars.next() {
-        Some(c) if c.is_ascii_alphanumeric() => {}
+        Some(c) if c.is_ascii_alphanumeric() || c == '-' || c == '_' => {}
         _ => return false,
     }
     let mut was_dash = false;
@@ -345,7 +345,7 @@ fn is_valid_cloud_name(name: &str) -> bool {
                 was_dash = true;
             }
         } else {
-            if !c.is_ascii_alphanumeric() {
+            if !(c.is_ascii_alphanumeric() || c == '_') {
                 return false;
             }
             was_dash = false;
@@ -377,7 +377,7 @@ impl FromStr for InstanceName {
             if !is_valid_cloud_name(org_slug) {
                 return Err(ClientError::with_message(format!(
                     "invalid cloud org name \"{}\", must follow \
-                     regex: ^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$",
+                     regex: ^-?[a-zA-Z0-9_]+(-[a-zA-Z0-9]+)*$",
                     org_slug,
                 )));
             }

--- a/edgedb-tokio/src/builder.rs
+++ b/edgedb-tokio/src/builder.rs
@@ -2341,6 +2341,10 @@ fn test_instance_name() {
         "abc-123/def-456",
         "123-abc/456-def",
         "a-b-c/1-2-3",
+        "-leading-dash/abc",
+        "_leading-underscore/abc",
+        "under_score/abc",
+        "-vicfg-hceTeOuz6iXr3vkXPf0Wsudd/test123",
     ] {
         match InstanceName::from_str(inst_name) {
             Ok(InstanceName::Local(name)) => assert_eq!(name, inst_name),
@@ -2359,14 +2363,12 @@ fn test_instance_name() {
         "-leading-dash",
         "trailing-dash-",
         "double--dash",
-        "-leading-dash/abc",
         "trailing-dash-/abc",
         "double--dash/abc",
         "abc/-leading-dash",
         "abc/trailing-dash-",
         "abc/double--dash",
         "abc/_localdev",
-        "under_score/abc",
         "123/45678901234567890123456789012345678901234567890123456789012345678901234567890",
     ] {
         assert!(


### PR DESCRIPTION
Needed by edgedb-cli: https://github.com/edgedb/edgedb-cli/pull/1361