### PR TITLE
Add pgdsn parameter

### DIFF
--- a/edgedb-tokio/src/raw/connection.rs
+++ b/edgedb-tokio/src/raw/connection.rs
@@ -502,6 +502,20 @@ async fn connect4(cfg: &Config, mut stream: TlsStream) -> Result<Connection, Err
                     };
                     server_params.set::<PostgresAddress>(pgaddr);
                 }
+                #[cfg(feature = "unstable")]
+                b"pgdsn" => {
+                    use crate::server_params::PostgresDsn;
+
+                    let pgdsn = match str::from_utf8(&par.value) {
+                        Ok(a) => a.to_owned(),
+                        Err(e) => {
+                            log::warn!("Can't decode param {:?}: {}", par.name, e);
+                            continue;
+                        }
+                    };
+
+                    server_params.set::<PostgresDsn>(PostgresDsn(pgdsn));
+                }
                 b"system_config" => {
                     handle_system_config(par, &mut server_params)?;
                 }

--- a/edgedb-tokio/src/server_params.rs
+++ b/edgedb-tokio/src/server_params.rs
@@ -33,6 +33,15 @@ impl ServerParam for PostgresAddress {
 
 impl SealedParam for PostgresAddress {}
 
+#[derive(Debug)]
+pub struct PostgresDsn(pub String);
+
+impl ServerParam for PostgresDsn {
+    type Value = PostgresDsn;
+}
+
+impl SealedParam for PostgresDsn {}
+
 /// ParameterStatus_SystemConfig
 #[derive(Debug)]
 pub struct SystemConfig {


### PR DESCRIPTION
`pgaddr` no longer exists as of 6.x -- parse `pgdsn` as well.