### PR TITLE
Warnings

### DIFF
--- a/edgedb-protocol/Cargo.toml
+++ b/edgedb-protocol/Cargo.toml
@@ -22,6 +22,7 @@ chrono = {version="0.4.23", optional=true, features=["std"], default-features=fa
 edgedb-errors = {path = "../edgedb-errors", version = "0.4.0" }
 bitflags = "2.4.0"
 serde = {version="1.0.190", features = ["derive"], optional=true}
+serde_json = {version="1", optional=true}
 
 [features]
 default = []
@@ -29,7 +30,7 @@ with-num-bigint = ["num-bigint", "num-traits"]
 with-bigdecimal = ["bigdecimal", "num-bigint", "num-traits"]
 with-chrono = ["chrono"]
 all-types = ["with-num-bigint", "with-bigdecimal", "with-chrono"]
-with-serde = ["serde"]
+with-serde = ["serde", "serde_json"]
 
 [dev-dependencies]
 rand = "0.8"

--- a/edgedb-protocol/src/annotations.rs
+++ b/edgedb-protocol/src/annotations.rs
@@ -1,0 +1,55 @@
+#[cfg(feature = "with-serde")]
+use crate::encoding::Annotations;
+
+/// CommandDataDescription1 may contain "warnings" annotations, whose value is
+/// a JSON array of this [Warning] type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Warning {
+    /// User-friendly explanation of the problem
+    message: String,
+
+    /// Name of the Python exception class
+    r#type: String,
+
+    /// Machine-friendly exception id
+    code: u64,
+
+    /// Name of the source file that caused the warning.
+    filename: Option<String>,
+
+    /// Additional user-friendly info
+    hint: Option<String>,
+
+    /// Developer-friendly explanation of why this problem occured
+    details: Option<String>,
+
+    /// Inclusive 0-based position within the source
+    start: Option<i64>,
+
+    /// Exclusive 0-based position within the source
+    end: Option<i64>,
+
+    /// 1-based index of the line of the start
+    line: Option<i64>,
+
+    /// 1-based index of the column of the start
+    col: Option<i64>,
+}
+
+#[cfg(feature = "with-serde")]
+pub fn decode_warnings(annotations: &Annotations) -> Result<Vec<Warning>, edgedb_errors::Error> {
+    use edgedb_errors::{ErrorKind, ProtocolEncodingError};
+
+    const ANN_NAME: &'static str = "warnings";
+
+    if let Some(warnings) = annotations.get(ANN_NAME) {
+        serde_json::from_str::<Vec<_>>(&warnings).map_err(|e| {
+            ProtocolEncodingError::with_source(e)
+                .context("Invalid JSON while decoding 'warnings' annotation")
+                .into()
+        })
+    } else {
+        Ok(vec![])
+    }
+}

--- a/edgedb-protocol/src/annotations.rs
+++ b/edgedb-protocol/src/annotations.rs
@@ -27,30 +27,30 @@ pub struct Warning {
     /// Inclusive 0-based position within the source
     #[cfg_attr(
         feature = "with-serde",
-        serde(deserialize_with = "deserialize_i64_from_str")
+        serde(deserialize_with = "deserialize_usize_from_str")
     )]
-    pub start: Option<i64>,
+    pub start: Option<usize>,
 
     /// Exclusive 0-based position within the source
     #[cfg_attr(
         feature = "with-serde",
-        serde(deserialize_with = "deserialize_i64_from_str")
+        serde(deserialize_with = "deserialize_usize_from_str")
     )]
-    pub end: Option<i64>,
+    pub end: Option<usize>,
 
     /// 1-based index of the line of the start
     #[cfg_attr(
         feature = "with-serde",
-        serde(deserialize_with = "deserialize_i64_from_str")
+        serde(deserialize_with = "deserialize_usize_from_str")
     )]
-    pub line: Option<i64>,
+    pub line: Option<usize>,
 
     /// 1-based index of the column of the start
     #[cfg_attr(
         feature = "with-serde",
-        serde(deserialize_with = "deserialize_i64_from_str")
+        serde(deserialize_with = "deserialize_usize_from_str")
     )]
-    pub col: Option<i64>,
+    pub col: Option<usize>,
 }
 
 impl std::fmt::Display for Warning {
@@ -91,21 +91,24 @@ pub fn decode_warnings(annotations: &Annotations) -> Result<Vec<Warning>, edgedb
 }
 
 #[cfg(feature = "with-serde")]
-fn deserialize_i64_from_str<'de, D: serde::Deserializer<'de>>(
+fn deserialize_usize_from_str<'de, D: serde::Deserializer<'de>>(
     deserializer: D,
-) -> Result<Option<i64>, D::Error> {
+) -> Result<Option<usize>, D::Error> {
     use serde::Deserialize;
 
     #[derive(Deserialize)]
     #[serde(untagged)]
     enum StringOrInt {
         String(String),
-        Number(i64),
+        Number(usize),
         None,
     }
 
     match StringOrInt::deserialize(deserializer)? {
-        StringOrInt::String(s) => s.parse::<i64>().map_err(serde::de::Error::custom).map(Some),
+        StringOrInt::String(s) => s
+            .parse::<usize>()
+            .map_err(serde::de::Error::custom)
+            .map(Some),
         StringOrInt::Number(i) => Ok(Some(i)),
         StringOrInt::None => Ok(None),
     }

--- a/edgedb-protocol/src/annotations.rs
+++ b/edgedb-protocol/src/annotations.rs
@@ -78,13 +78,12 @@ impl std::fmt::Display for Warning {
 pub fn decode_warnings(annotations: &Annotations) -> Result<Vec<Warning>, edgedb_errors::Error> {
     use edgedb_errors::{ErrorKind, ProtocolEncodingError};
 
-    const ANN_NAME: &'static str = "warnings";
+    const ANN_NAME: &str = "warnings";
 
     if let Some(warnings) = annotations.get(ANN_NAME) {
-        serde_json::from_str::<Vec<_>>(&warnings).map_err(|e| {
+        serde_json::from_str::<Vec<_>>(warnings).map_err(|e| {
             ProtocolEncodingError::with_source(e)
                 .context("Invalid JSON while decoding 'warnings' annotation")
-                .into()
         })
     } else {
         Ok(vec![])

--- a/edgedb-protocol/src/annotations.rs
+++ b/edgedb-protocol/src/annotations.rs
@@ -53,6 +53,27 @@ pub struct Warning {
     pub col: Option<i64>,
 }
 
+impl std::fmt::Display for Warning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Warning {
+            filename,
+            line,
+            col,
+            r#type,
+            message,
+            ..
+        } = self;
+        let filename = filename
+            .as_ref()
+            .map(|f| format!("{f}:"))
+            .unwrap_or_default();
+        let line = line.clone().unwrap_or(1);
+        let col = col.clone().unwrap_or(1);
+
+        write!(f, "{type} at {filename}{line}:{col} {message}")
+    }
+}
+
 #[cfg(feature = "with-serde")]
 pub fn decode_warnings(annotations: &Annotations) -> Result<Vec<Warning>, edgedb_errors::Error> {
     use edgedb_errors::{ErrorKind, ProtocolEncodingError};

--- a/edgedb-protocol/src/annotations.rs
+++ b/edgedb-protocol/src/annotations.rs
@@ -7,34 +7,34 @@ use crate::encoding::Annotations;
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Warning {
     /// User-friendly explanation of the problem
-    message: String,
+    pub message: String,
 
     /// Name of the Python exception class
-    r#type: String,
+    pub r#type: String,
 
     /// Machine-friendly exception id
-    code: u64,
+    pub code: u64,
 
     /// Name of the source file that caused the warning.
-    filename: Option<String>,
+    pub filename: Option<String>,
 
     /// Additional user-friendly info
-    hint: Option<String>,
+    pub hint: Option<String>,
 
     /// Developer-friendly explanation of why this problem occured
-    details: Option<String>,
+    pub details: Option<String>,
 
     /// Inclusive 0-based position within the source
-    start: Option<i64>,
+    pub start: Option<i64>,
 
     /// Exclusive 0-based position within the source
-    end: Option<i64>,
+    pub end: Option<i64>,
 
     /// 1-based index of the line of the start
-    line: Option<i64>,
+    pub line: Option<i64>,
 
     /// 1-based index of the column of the start
-    col: Option<i64>,
+    pub col: Option<i64>,
 }
 
 #[cfg(feature = "with-serde")]

--- a/edgedb-protocol/src/errors.rs
+++ b/edgedb-protocol/src/errors.rs
@@ -97,6 +97,11 @@ pub enum DecodeError {
     },
     #[snafu(display("missing required link or property"))]
     MissingRequiredElement { backtrace: Backtrace },
+    #[snafu(display("invalid format of {annotation} annotation"))]
+    InvalidAnnotationFormat {
+        backtrace: Backtrace,
+        annotation: &'static str,
+    },
 }
 
 #[derive(Snafu, Debug)]

--- a/edgedb-protocol/src/lib.rs
+++ b/edgedb-protocol/src/lib.rs
@@ -73,8 +73,8 @@ pub mod server_message;
 pub mod value;
 #[macro_use]
 pub mod value_opt;
+pub mod annotations;
 pub mod model;
 pub mod query_arg;
-pub mod annotations;
 
 pub use query_result::QueryResult;

--- a/edgedb-protocol/src/lib.rs
+++ b/edgedb-protocol/src/lib.rs
@@ -75,5 +75,6 @@ pub mod value;
 pub mod value_opt;
 pub mod model;
 pub mod query_arg;
+pub mod annotations;
 
 pub use query_result::QueryResult;

--- a/edgedb-tokio/Cargo.toml
+++ b/edgedb-tokio/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 rust-version.workspace = true
 
 [dependencies]
-edgedb-protocol = { path = "../edgedb-protocol", version = "0.6.0" }
+edgedb-protocol = { path = "../edgedb-protocol", version = "0.6.0", features = ["with-serde"] }
 edgedb-errors = { path = "../edgedb-errors", version = "0.4.1" }
 edgedb-derive = { path = "../edgedb-derive", version = "0.5.1", optional = true }
 tokio = { version = "1.15", features = ["net", "time", "sync", "macros"] }

--- a/edgedb-tokio/src/client.rs
+++ b/edgedb-tokio/src/client.rs
@@ -1,7 +1,6 @@
 use std::future::Future;
 use std::sync::Arc;
 
-use edgedb_protocol::annotations::Warning;
 use edgedb_protocol::common::{Capabilities, Cardinality, IoFormat};
 use edgedb_protocol::model::Json;
 use edgedb_protocol::query_arg::QueryArgs;
@@ -17,6 +16,7 @@ use crate::raw::{Pool, QueryCapabilities};
 use crate::state::{AliasesDelta, ConfigDelta, GlobalsDelta};
 use crate::state::{AliasesModifier, ConfigModifier, Fn, GlobalsModifier};
 use crate::transaction::{transaction, Transaction};
+use crate::ResultVerbose;
 
 /// The EdgeDB Client.
 ///
@@ -123,18 +123,18 @@ impl Client {
     /// This method can be used with both static arguments, like a tuple of
     /// scalars, and with dynamic arguments [`edgedb_protocol::value::Value`].
     /// Similarly, dynamically typed results are also supported.
-    pub async fn query_with_warnings<R, A>(
+    pub async fn query_verbose<R, A>(
         &self,
         query: impl AsRef<str> + Send,
         arguments: &A,
-    ) -> Result<(Vec<R>, Vec<Warning>), Error>
+    ) -> Result<ResultVerbose<Vec<R>>, Error>
     where
         A: QueryArgs,
         R: QueryResult,
     {
         Client::query_helper(self, query, arguments, IoFormat::Binary, Cardinality::Many)
             .await
-            .map(|x| (x.data, x.warnings))
+            .map(|Response { data, warnings, .. }| ResultVerbose { data, warnings })
     }
 
     /// Execute a query and return a collection of results.

--- a/edgedb-tokio/src/client.rs
+++ b/edgedb-tokio/src/client.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
 use std::sync::Arc;
 
+use edgedb_protocol::annotations::Warning;
 use edgedb_protocol::common::{Capabilities, Cardinality, IoFormat};
 use edgedb_protocol::model::Json;
 use edgedb_protocol::query_arg::QueryArgs;
@@ -11,7 +12,7 @@ use crate::builder::Config;
 use crate::errors::NoDataError;
 use crate::errors::{Error, ErrorKind, SHOULD_RETRY};
 use crate::options::{RetryOptions, TransactionOptions};
-use crate::raw::{Options, PoolState};
+use crate::raw::{Options, PoolState, Response};
 use crate::raw::{Pool, QueryCapabilities};
 use crate::state::{AliasesDelta, ConfigDelta, GlobalsDelta};
 use crate::state::{AliasesModifier, ConfigModifier, Fn, GlobalsModifier};
@@ -56,13 +57,14 @@ impl Client {
         Ok(())
     }
 
-    async fn query_and_retry<R, A>(
+    /// Query with retry.
+    async fn query_helper<R, A>(
         &self,
         query: impl AsRef<str>,
         arguments: &A,
         io_format: IoFormat,
         cardinality: Cardinality,
-    ) -> Result<Vec<R>, Error>
+    ) -> Result<Response<Vec<R>>, Error>
     where
         A: QueryArgs,
         R: QueryResult,
@@ -85,7 +87,7 @@ impl Client {
                 )
                 .await
             {
-                Ok(resp) => return Ok(resp.data),
+                Ok(resp) => return Ok(resp),
                 Err(e) => {
                     let allow_retry = match e.get::<QueryCapabilities>() {
                         // Error from a weird source, or just a bug
@@ -108,6 +110,31 @@ impl Client {
                 }
             }
         }
+    }
+
+    /// Execute a query and return a collection of results and warnings produced by the server.
+    ///
+    /// You will usually have to specify the return type for the query:
+    ///
+    /// ```rust,ignore
+    /// let greeting: (Vec<String>, _) = conn.query_with_warnings("select 'hello'", &()).await?;
+    /// ```
+    ///
+    /// This method can be used with both static arguments, like a tuple of
+    /// scalars, and with dynamic arguments [`edgedb_protocol::value::Value`].
+    /// Similarly, dynamically typed results are also supported.
+    pub async fn query_with_warnings<R, A>(
+        &self,
+        query: impl AsRef<str> + Send,
+        arguments: &A,
+    ) -> Result<(Vec<R>, Vec<Warning>), Error>
+    where
+        A: QueryArgs,
+        R: QueryResult,
+    {
+        Client::query_helper(self, query, arguments, IoFormat::Binary, Cardinality::Many)
+            .await
+            .map(|x| (x.data, x.warnings))
     }
 
     /// Execute a query and return a collection of results.
@@ -134,7 +161,9 @@ impl Client {
         A: QueryArgs,
         R: QueryResult,
     {
-        Client::query_and_retry(self, query, arguments, IoFormat::Binary, Cardinality::Many).await
+        Client::query_helper(self, query, arguments, IoFormat::Binary, Cardinality::Many)
+            .await
+            .map(|r| r.data)
     }
 
     /// Execute a query and return a single result
@@ -162,7 +191,7 @@ impl Client {
         A: QueryArgs,
         R: QueryResult + Send,
     {
-        Client::query_and_retry(
+        Client::query_helper(
             self,
             query,
             arguments,
@@ -170,7 +199,7 @@ impl Client {
             Cardinality::AtMostOne,
         )
         .await
-        .map(|x| x.into_iter().next())
+        .map(|x| x.data.into_iter().next())
     }
 
     /// Execute a query and return a single result
@@ -207,7 +236,7 @@ impl Client {
         A: QueryArgs,
         R: QueryResult + Send,
     {
-        Client::query_and_retry(
+        Client::query_helper(
             self,
             query,
             arguments,
@@ -216,7 +245,8 @@ impl Client {
         )
         .await
         .and_then(|x| {
-            x.into_iter()
+            x.data
+                .into_iter()
                 .next()
                 .ok_or_else(|| NoDataError::with_message("query row returned zero results"))
         })
@@ -229,10 +259,11 @@ impl Client {
         arguments: &impl QueryArgs,
     ) -> Result<Json, Error> {
         let res = self
-            .query_and_retry::<String, _>(query, arguments, IoFormat::Json, Cardinality::Many)
+            .query_helper::<String, _>(query, arguments, IoFormat::Json, Cardinality::Many)
             .await?;
 
         let json = res
+            .data
             .into_iter()
             .next()
             .ok_or_else(|| NoDataError::with_message("query row returned zero results"))?;
@@ -266,11 +297,11 @@ impl Client {
         arguments: &impl QueryArgs,
     ) -> Result<Option<Json>, Error> {
         let res = self
-            .query_and_retry::<String, _>(query, arguments, IoFormat::Json, Cardinality::AtMostOne)
+            .query_helper::<String, _>(query, arguments, IoFormat::Json, Cardinality::AtMostOne)
             .await?;
 
         // we trust database to produce valid json
-        Ok(res.into_iter().next().map(Json::new_unchecked))
+        Ok(res.data.into_iter().next().map(Json::new_unchecked))
     }
 
     /// Execute a query and return a single result as JSON.

--- a/edgedb-tokio/src/lib.rs
+++ b/edgedb-tokio/src/lib.rs
@@ -146,7 +146,7 @@ pub use client::Client;
 pub use credentials::TlsSecurity;
 pub use errors::Error;
 pub use options::{RetryCondition, RetryOptions, TransactionOptions};
-pub use query_executor::QueryExecutor;
+pub use query_executor::{QueryExecutor, ResultVerbose};
 pub use state::{ConfigDelta, GlobalsDelta};
 pub use transaction::Transaction;
 

--- a/edgedb-tokio/src/query_executor.rs
+++ b/edgedb-tokio/src/query_executor.rs
@@ -5,6 +5,12 @@ use std::future::Future;
 
 use crate::{Client, Error, Transaction};
 
+#[non_exhaustive]
+pub struct ResultVerbose<R> {
+    pub data: R,
+    pub warnings: Vec<Warning>,
+}
+
 /// Abstracts over different query executors
 /// In particular &Client and &mut Transaction
 pub trait QueryExecutor: Sized {
@@ -19,11 +25,11 @@ pub trait QueryExecutor: Sized {
         R: QueryResult + Send;
 
     /// see [Client::query_with_warnings]
-    fn query_with_warnings<R, A>(
+    fn query_verbose<R, A>(
         self,
         query: impl AsRef<str> + Send,
         arguments: &A,
-    ) -> impl Future<Output = Result<(Vec<R>, Vec<Warning>), Error>> + Send
+    ) -> impl Future<Output = Result<ResultVerbose<Vec<R>>, Error>> + Send
     where
         A: QueryArgs,
         R: QueryResult + Send;
@@ -92,16 +98,16 @@ impl QueryExecutor for &Client {
         Client::query(self, query, arguments)
     }
 
-    fn query_with_warnings<R, A>(
+    fn query_verbose<R, A>(
         self,
         query: impl AsRef<str> + Send,
         arguments: &A,
-    ) -> impl Future<Output = Result<(Vec<R>, Vec<Warning>), Error>> + Send
+    ) -> impl Future<Output = Result<ResultVerbose<Vec<R>>, Error>> + Send
     where
         A: QueryArgs,
         R: QueryResult + Send,
     {
-        Client::query_with_warnings(self, query, arguments)
+        Client::query_verbose(self, query, arguments)
     }
 
     fn query_single<R, A>(
@@ -173,16 +179,16 @@ impl QueryExecutor for &mut Transaction {
         Transaction::query(self, query, arguments)
     }
 
-    fn query_with_warnings<R, A>(
+    fn query_verbose<R, A>(
         self,
         query: impl AsRef<str> + Send,
         arguments: &A,
-    ) -> impl Future<Output = Result<(Vec<R>, Vec<Warning>), Error>> + Send
+    ) -> impl Future<Output = Result<ResultVerbose<Vec<R>>, Error>> + Send
     where
         A: QueryArgs,
         R: QueryResult + Send,
     {
-        Transaction::query_with_warnings(self, query, arguments)
+        Transaction::query_verbose(self, query, arguments)
     }
 
     fn query_single<R, A>(

--- a/edgedb-tokio/src/query_executor.rs
+++ b/edgedb-tokio/src/query_executor.rs
@@ -1,6 +1,6 @@
-use edgedb_protocol::model::Json;
 use edgedb_protocol::query_arg::QueryArgs;
 use edgedb_protocol::QueryResult;
+use edgedb_protocol::{annotations::Warning, model::Json};
 use std::future::Future;
 
 use crate::{Client, Error, Transaction};
@@ -14,6 +14,16 @@ pub trait QueryExecutor: Sized {
         query: impl AsRef<str> + Send,
         arguments: &A,
     ) -> impl Future<Output = Result<Vec<R>, Error>> + Send
+    where
+        A: QueryArgs,
+        R: QueryResult + Send;
+
+    /// see [Client::query_with_warnings]
+    fn query_with_warnings<R, A>(
+        self,
+        query: impl AsRef<str> + Send,
+        arguments: &A,
+    ) -> impl Future<Output = Result<(Vec<R>, Vec<Warning>), Error>> + Send
     where
         A: QueryArgs,
         R: QueryResult + Send;
@@ -80,6 +90,18 @@ impl QueryExecutor for &Client {
         R: QueryResult,
     {
         Client::query(self, query, arguments)
+    }
+
+    fn query_with_warnings<R, A>(
+        self,
+        query: impl AsRef<str> + Send,
+        arguments: &A,
+    ) -> impl Future<Output = Result<(Vec<R>, Vec<Warning>), Error>> + Send
+    where
+        A: QueryArgs,
+        R: QueryResult + Send,
+    {
+        Client::query_with_warnings(self, query, arguments)
     }
 
     fn query_single<R, A>(
@@ -149,6 +171,18 @@ impl QueryExecutor for &mut Transaction {
         R: QueryResult,
     {
         Transaction::query(self, query, arguments)
+    }
+
+    fn query_with_warnings<R, A>(
+        self,
+        query: impl AsRef<str> + Send,
+        arguments: &A,
+    ) -> impl Future<Output = Result<(Vec<R>, Vec<Warning>), Error>> + Send
+    where
+        A: QueryArgs,
+        R: QueryResult + Send,
+    {
+        Transaction::query_with_warnings(self, query, arguments)
     }
 
     fn query_single<R, A>(

--- a/edgedb-tokio/src/raw/dumps.rs
+++ b/edgedb-tokio/src/raw/dumps.rs
@@ -118,6 +118,7 @@ impl Connection {
                         status_data: complete.status_data,
                         new_state: None,
                         data: (),
+                        warnings: vec![],
                     });
                 }
                 ServerMessage::CommandComplete1(complete) => {
@@ -127,6 +128,7 @@ impl Connection {
                         status_data: complete.status_data,
                         new_state: complete.state,
                         data: (),
+                        warnings: vec![],
                     });
                 }
                 ServerMessage::ErrorResponse(err) => {
@@ -220,6 +222,7 @@ impl DumpStream<'_> {
                             status_data: complete.status_data,
                             new_state: None,
                             data: (),
+                            warnings: vec![],
                         });
                     }
                     None
@@ -235,6 +238,7 @@ impl DumpStream<'_> {
                             status_data: complete.status_data,
                             new_state: complete.state,
                             data: (),
+                            warnings: vec![],
                         });
                     }
                     None

--- a/edgedb-tokio/src/raw/mod.rs
+++ b/edgedb-tokio/src/raw/mod.rs
@@ -182,4 +182,11 @@ impl<T> Response<T> {
             warnings: self.warnings,
         })
     }
+
+    fn log_warnings(&self) {
+        for w in &self.warnings {
+            // TODO: pretty print
+            log::warn!(target: "", "Server warning: {}", w.message)
+        }
+    }
 }

--- a/edgedb-tokio/src/raw/mod.rs
+++ b/edgedb-tokio/src/raw/mod.rs
@@ -13,7 +13,6 @@ use std::sync::{Arc, Mutex as BlockingMutex};
 use std::time::Duration;
 
 use bytes::{Bytes, BytesMut};
-use edgedb_protocol::annotations::Warning;
 use tls_api::TlsStream;
 use tokio::sync::{self, Semaphore};
 
@@ -186,25 +185,7 @@ impl<T> Response<T> {
 
     fn log_warnings(&self) {
         for w in &self.warnings {
-            let Warning {
-                filename,
-                line,
-                col,
-                r#type,
-                message,
-                ..
-            } = w;
-            let filename = filename
-                .as_ref()
-                .map(|f| format!("{f}:"))
-                .unwrap_or_default();
-            let line = line.clone().unwrap_or(1);
-            let col = col.clone().unwrap_or(1);
-
-            log::warn!(
-                target: "edgedb_tokio::warning",
-                "{type} at {filename}{line}:{col} {message}"
-            )
+            log::warn!(target: "edgedb_tokio::warning", "{w}");
         }
     }
 }

--- a/edgedb-tokio/src/raw/mod.rs
+++ b/edgedb-tokio/src/raw/mod.rs
@@ -75,6 +75,7 @@ pub struct Response<T> {
     pub status_data: Bytes,
     pub new_state: Option<edgedb_protocol::common::State>,
     pub data: T,
+    pub warnings: Vec<edgedb_protocol::annotations::Warning>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -178,6 +179,7 @@ impl<T> Response<T> {
             status_data: self.status_data,
             new_state: self.new_state,
             data: f(self.data)?,
+            warnings: self.warnings,
         })
     }
 }

--- a/edgedb-tokio/src/raw/queries.rs
+++ b/edgedb-tokio/src/raw/queries.rs
@@ -592,6 +592,7 @@ impl Connection {
             let response = self
                 ._execute(&flags, query, state, &desc, &arg_buf.freeze())
                 .await?;
+            response.log_warnings();
 
             let out_desc = desc.output().map_err(ProtocolEncodingError::with_source)?;
             match out_desc.root_pos() {
@@ -645,10 +646,11 @@ impl Connection {
                 return Err(e.set::<Description>(desc));
             }
 
-            let res = self
+            let response = self
                 ._execute(&flags, query, state, &desc, &arg_buf.freeze())
                 .await?;
-            res.map(|_| Ok::<_, Error>(()))
+            response.log_warnings();
+            response.map(|_| Ok::<_, Error>(()))
         }
         .await;
         result.map_err(|e| e.set::<QueryCapabilities>(caps))

--- a/edgedb-tokio/src/raw/response.rs
+++ b/edgedb-tokio/src/raw/response.rs
@@ -289,12 +289,14 @@ where
                     vec![]
                 };
 
-                Ok(Response {
+                let response = Response {
                     status_data,
                     new_state,
                     data: (),
                     warnings,
-                })
+                };
+                response.log_warnings();
+                Ok(response)
             }
             Error(e) => Err(e),
             ErrorResponse(e) => {

--- a/edgedb-tokio/src/raw/response.rs
+++ b/edgedb-tokio/src/raw/response.rs
@@ -5,6 +5,7 @@ use bytes::Bytes;
 use edgedb_errors::ProtocolEncodingError;
 use edgedb_errors::{Error, ErrorKind};
 use edgedb_errors::{ParameterTypeMismatchError, ProtocolOutOfOrderError};
+use edgedb_protocol::annotations::Warning;
 use edgedb_protocol::common::State;
 use edgedb_protocol::descriptors::Typedesc;
 use edgedb_protocol::server_message::CommandDataDescription1;
@@ -34,6 +35,7 @@ where
     state: Option<T::State>,
     guard: Option<Guard>,
     description: Option<CommandDataDescription1>,
+    warnings: Vec<Warning>,
 }
 
 impl<'a, T: QueryResult> ResponseStream<'a, T>
@@ -108,6 +110,11 @@ where
                 }
             }
         }
+        let warnings = description
+            .as_ref()
+            .map(|d| annotations::decode_warnings(&d.annotations))
+            .transpose()?
+            .unwrap_or_default();
         let computed_desc = description
             .as_ref()
             .map(|d| d.output())
@@ -123,6 +130,7 @@ where
                 state: Some(state),
                 guard,
                 description,
+                warnings,
             })
         } else {
             Ok(ResponseStream {
@@ -131,6 +139,7 @@ where
                 state: None,
                 guard,
                 description,
+                warnings,
             })
         }
     }
@@ -268,6 +277,9 @@ where
             }
         }
     }
+    pub fn warnings(&self) -> &[Warning] {
+        &self.warnings
+    }
     pub async fn complete(mut self) -> Result<Response<()>, Error> {
         self.process_complete().await
     }
@@ -283,12 +295,7 @@ where
                 status_data,
                 new_state,
             } => {
-                let warnings = if let Some(d) = &self.description {
-                    annotations::decode_warnings(&d.annotations)?
-                } else {
-                    vec![]
-                };
-
+                let warnings = std::mem::take(&mut self.warnings);
                 let response = Response {
                     status_data,
                     new_state,

--- a/edgedb-tokio/src/transaction.rs
+++ b/edgedb-tokio/src/transaction.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::sync::Arc;
 
 use bytes::BytesMut;
+use edgedb_protocol::annotations::Warning;
 use edgedb_protocol::common::CompilationOptions;
 use edgedb_protocol::common::{Capabilities, Cardinality, IoFormat};
 use edgedb_protocol::model::Json;
@@ -13,7 +14,7 @@ use tokio::time::sleep;
 use crate::errors::ClientError;
 use crate::errors::{Error, ErrorKind, SHOULD_RETRY};
 use crate::errors::{NoDataError, ProtocolEncodingError};
-use crate::raw::{Options, Pool, PoolConnection, PoolState};
+use crate::raw::{Options, Pool, PoolConnection, PoolState, Response};
 
 /// Transaction object passed to the closure via
 /// [`Client::transaction()`](crate::Client::transaction) method
@@ -156,7 +157,7 @@ impl Transaction {
         arguments: &A,
         io_format: IoFormat,
         cardinality: Cardinality,
-    ) -> Result<Vec<R>, Error>
+    ) -> Result<Response<Vec<R>>, Error>
     where
         A: QueryArgs,
         R: QueryResult,
@@ -175,7 +176,6 @@ impl Transaction {
                 cardinality,
             )
             .await
-            .map(|x| x.data)
     }
 
     /// Execute a query and return a collection of results.
@@ -183,9 +183,9 @@ impl Transaction {
     /// You will usually have to specify the return type for the query:
     ///
     /// ```rust,ignore
-    /// let greeting = pool.query::<String, _>("SELECT 'hello'", &());
+    /// let greeting = tran.query::<String, _>("SELECT 'hello'", &());
     /// // or
-    /// let greeting: Vec<String> = pool.query("SELECT 'hello'", &());
+    /// let greeting: Vec<String> = tran.query("SELECT 'hello'", &());
     /// ```
     ///
     /// This method can be used with both static arguments, like a tuple of
@@ -202,6 +202,32 @@ impl Transaction {
     {
         self.query_helper(query, arguments, IoFormat::Binary, Cardinality::Many)
             .await
+            .map(|x| x.data)
+    }
+
+    /// Execute a query and return a collection of results and warnings produced by the server.
+    ///
+    /// You will usually have to specify the return type for the query:
+    ///
+    /// ```rust,ignore
+    /// let greeting: (Vec<String>, _) = tran.query_with_warnings("select 'hello'", &()).await?;
+    /// ```
+    ///
+    /// This method can be used with both static arguments, like a tuple of
+    /// scalars, and with dynamic arguments [`edgedb_protocol::value::Value`].
+    /// Similarly, dynamically typed results are also supported.
+    pub async fn query_with_warnings<R, A>(
+        &mut self,
+        query: impl AsRef<str> + Send,
+        arguments: &A,
+    ) -> Result<(Vec<R>, Vec<Warning>), Error>
+    where
+        A: QueryArgs,
+        R: QueryResult,
+    {
+        self.query_helper(query, arguments, IoFormat::Binary, Cardinality::Many)
+            .await
+            .map(|x| (x.data, x.warnings))
     }
 
     /// Execute a query and return a single result
@@ -215,12 +241,12 @@ impl Transaction {
     /// You will usually have to specify the return type for the query:
     ///
     /// ```rust,ignore
-    /// let greeting = pool.query_required_single::<String, _>(
+    /// let greeting = tran.query_required_single::<String, _>(
     ///     "SELECT 'hello'",
     ///     &(),
     /// );
     /// // or
-    /// let greeting: String = pool.query_required_single(
+    /// let greeting: String = tran.query_required_single(
     ///     "SELECT 'hello'",
     ///     &(),
     /// );
@@ -240,7 +266,7 @@ impl Transaction {
     {
         self.query_helper(query, arguments, IoFormat::Binary, Cardinality::AtMostOne)
             .await
-            .map(|x| x.into_iter().next())
+            .map(|x| x.data.into_iter().next())
     }
 
     /// Execute a query and return a single result
@@ -254,12 +280,12 @@ impl Transaction {
     /// You will usually have to specify the return type for the query:
     ///
     /// ```rust,ignore
-    /// let greeting = pool.query_required_single::<String, _>(
+    /// let greeting = tran.query_required_single::<String, _>(
     ///     "SELECT 'hello'",
     ///     &(),
     /// );
     /// // or
-    /// let greeting: String = pool.query_required_single(
+    /// let greeting: String = tran.query_required_single(
     ///     "SELECT 'hello'",
     ///     &(),
     /// );
@@ -280,7 +306,8 @@ impl Transaction {
         self.query_helper(query, arguments, IoFormat::Binary, Cardinality::AtMostOne)
             .await
             .and_then(|x| {
-                x.into_iter()
+                x.data
+                    .into_iter()
                     .next()
                     .ok_or_else(|| NoDataError::with_message("query row returned zero results"))
             })
@@ -297,6 +324,7 @@ impl Transaction {
             .await?;
 
         let json = res
+            .data
             .into_iter()
             .next()
             .ok_or_else(|| NoDataError::with_message("query row returned zero results"))?;
@@ -321,7 +349,7 @@ impl Transaction {
             .await?;
 
         // we trust database to produce valid json
-        Ok(res.into_iter().next().map(Json::new_unchecked))
+        Ok(res.data.into_iter().next().map(Json::new_unchecked))
     }
 
     /// Execute a query and return a single result as JSON.

--- a/edgedb-tokio/tests/func/client.rs
+++ b/edgedb-tokio/tests/func/client.rs
@@ -279,3 +279,19 @@ async fn wrong_field_number() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn warnings() -> anyhow::Result<()> {
+    let client = Client::new(&SERVER.config);
+    client.ensure_connected().await?;
+
+    let (_ints, warnings) = client
+        .query_with_warnings::<i64, _>("select std::_warn_on_call()", &())
+        .await
+        .unwrap();
+    assert_eq!(warnings.len(), 1);
+
+    // TODO: test that the warning is logged
+
+    Ok(())
+}

--- a/edgedb-tokio/tests/func/client.rs
+++ b/edgedb-tokio/tests/func/client.rs
@@ -285,11 +285,11 @@ async fn warnings() -> anyhow::Result<()> {
     let client = Client::new(&SERVER.config);
     client.ensure_connected().await?;
 
-    let (_ints, warnings) = client
-        .query_with_warnings::<i64, _>("select std::_warn_on_call()", &())
+    let res = client
+        .query_verbose::<i64, _>("select std::_warn_on_call()", &())
         .await
         .unwrap();
-    assert_eq!(warnings.len(), 1);
+    assert_eq!(res.warnings.len(), 1);
 
     // TODO: test that the warning is logged
 

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720422321,
-        "narHash": "sha256-6AOBQSP17xz0JjE5pI/ao/cFhMw6CiWJIE0NfxmAm34=",
+        "lastModified": 1728464304,
+        "narHash": "sha256-Pr5eF+oN7/2WyDlBzcLObCDhA/9qNOW0wVvAtG8Zf+Y=",
         "owner": "edgedb",
         "repo": "packages-nix",
-        "rev": "ec9d4c9bbde1e95e5b087163e96ceb707b485530",
+        "rev": "ec0a3377e1a15633b7bf5d91c2a8515d55f6b292",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728464304,
-        "narHash": "sha256-Pr5eF+oN7/2WyDlBzcLObCDhA/9qNOW0wVvAtG8Zf+Y=",
+        "lastModified": 1728494477,
+        "narHash": "sha256-cbDdK/BlNmvqUXnUi2zWpR9bgHAWIjLr9en2ujLHMM0=",
         "owner": "edgedb",
         "repo": "packages-nix",
-        "rev": "ec0a3377e1a15633b7bf5d91c2a8515d55f6b292",
+        "rev": "eb1a1ac4f0f41b1b918baa3ce88baac7647b6a5b",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1723012113,
-        "narHash": "sha256-AJGsmwDnheWMjZWUqgiGtBjbxMmvLvMp5WJhmTRhJ4w=",
+        "lastModified": 1728455642,
+        "narHash": "sha256-abYGwrL6ak5sBRqwPh+V3CPJ6Pa89p378t51b7BO1lE=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "3dab4ada5b0c5a22d56dbfd7e140c16f3df2e69a",
+        "rev": "3b47535a5c782e4f4ad59cd4bdb23636b6926e03",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
         "type": "github"
       },
       "original": {
@@ -89,11 +89,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723031421,
-        "narHash": "sha256-Q4iMzihS+4mzCadp+ADr782Jrd1Mgvr7lLZbkWx33Hw=",
+        "lastModified": 1728493385,
+        "narHash": "sha256-ryNG62K/XVIKt9/bBQxcavi3NOD/KHU2QRR+N4Z5xQA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1602c0d3c0247d23eb7ca501c3e592aa1762e37b",
+        "rev": "516e84444d8aaaca070aba846b9c1015452f1a00",
         "type": "github"
       },
       "original": {
@@ -104,14 +104,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1722555339,
-        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "lastModified": 1727825735,
+        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             pkgs.just
 
             # needed for tests
-            edgedb.packages.${system}.edgedb-server
+            edgedb.packages.${system}.edgedb-server-nightly
             edgedb.packages.${system}.edgedb-cli
           ]
           ++ pkgs.lib.optional pkgs.stdenv.isDarwin [


### PR DESCRIPTION
- reads annotation "warnings" from [CommandDataDescription](https://docs.edgedb.com/database/reference/protocol/messages#commanddatadescription),
- logs these warnings via log crate (at warn level),
- adds a new QueryExecutor function `query_with_warnings`

I'm not sure on the function name here, should it be changed to `query_full` or `query_verbose`?