### PR TITLE
Support both gel.toml and edgedb.toml

### DIFF
--- a/edgedb-tokio/src/lib.rs
+++ b/edgedb-tokio/src/lib.rs
@@ -159,8 +159,8 @@ pub use builder::get_project_dir;
 /// Create a connection to the database with default parameters
 ///
 /// It's expected that connection parameters are set up using environment
-/// (either environment variables or project configuration in
-/// `gel.toml`/`edgedb.toml`) so no configuration is specified here.
+/// (either environment variables or project configuration in a file named by
+/// [`PROJECT_FILES`]) so no configuration is specified here.
 ///
 /// This method tries to esablish single connection immediately to ensure that
 /// configuration is valid and will error out otherwise.

--- a/edgedb-tokio/src/lib.rs
+++ b/edgedb-tokio/src/lib.rs
@@ -150,20 +150,23 @@ pub use query_executor::{QueryExecutor, ResultVerbose};
 pub use state::{ConfigDelta, GlobalsDelta};
 pub use transaction::Transaction;
 
+/// The ordered list of project filenames supported.
+pub const PROJECT_FILES: &[&str] = &["gel.toml", "edgedb.toml"];
+
 #[cfg(feature = "unstable")]
 pub use builder::get_project_dir;
 
 /// Create a connection to the database with default parameters
 ///
 /// It's expected that connection parameters are set up using environment
-/// (either environment variables or project configuration in `edgedb.toml`)
-/// so no configuration is specified here.
+/// (either environment variables or project configuration in
+/// `gel.toml`/`edgedb.toml`) so no configuration is specified here.
 ///
-/// This method tries to esablish single connection immediately to
-/// ensure that configuration is valid and will error out otherwise.
+/// This method tries to esablish single connection immediately to ensure that
+/// configuration is valid and will error out otherwise.
 ///
-/// For more fine-grained setup see [`Client`] and [`Builder`] documentation
-/// and the source of this function.
+/// For more fine-grained setup see [`Client`] and [`Builder`] documentation and
+/// the source of this function.
 #[cfg(feature = "env")]
 pub async fn create_client() -> Result<Client, Error> {
     let pool = Client::new(&Builder::new().build_env().await?);


### PR DESCRIPTION
We allow multiple configuration files to be found in one folder but you must ensure that they contain the same contents (either via copy or symlink).