### PR TITLE
Remove nix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install EdgeDB
-        run: bash <(curl --proto '=https' --tlsv1.2 -sSf https://sh.edgedb.com) --nightly 
+        run: bash <(curl --proto '=https' --tlsv1.2 -sSf https://sh.edgedb.com) --nightly -y
 
       - name: setup rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install EdgeDB
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.edgedb.com | sh
+        run: bash <(curl --proto '=https' --tlsv1.2 -sSf https://sh.edgedb.com) --nightly 
 
       - name: setup rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,21 +8,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_version: [default, minimum, beta]
+        rust_version: [default, 1.75, beta]
       fail-fast: false
     timeout-minutes: 30
     permissions:
       id-token: "write"
       contents: "read"
     steps:
-      # checkout and env setup
-      - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-      - name: Build the nix shell
-        run: nix develop .#${{ matrix.rust_version }} --command just --version
-      - uses: Swatinem/rust-cache@v2
+      # Test all features
+      - cargo test --workspace --all-features
+      # Check no default features
+      - cargo check --no-default-features --workspace
+      # Check `fs` feature (edgedb-tokio)
+      - cargo check --features=fs --package edgedb-tokio
+      # Check with env feature, edgedb-tokio
+      - cargo check --features=env --package edgedb-tokio
+      # Test edgedb-protocol without default features
+      - cargo test --package=edgedb-protocol --no-default-features
+      # Test edgedb-protocol with "all-types" feature
+      - cargo test --package=edgedb-protocol --features=all-types
+      - cargo clippy --workspace --all-features --all-targets
+      - cargo fmt --check
 
-      # run tests
-      - name: Run tests
-        run: nix develop .#${{ matrix.rust_version }} --command just test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,18 +15,38 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      # Test all features
-      - cargo test --workspace --all-features
-      # Check no default features
-      - cargo check --no-default-features --workspace
-      # Check `fs` feature (edgedb-tokio)
-      - cargo check --features=fs --package edgedb-tokio
-      # Check with env feature, edgedb-tokio
-      - cargo check --features=env --package edgedb-tokio
-      # Test edgedb-protocol without default features
-      - cargo test --package=edgedb-protocol --no-default-features
-      # Test edgedb-protocol with "all-types" feature
-      - cargo test --package=edgedb-protocol --features=all-types
-      - cargo clippy --workspace --all-features --all-targets
-      - cargo fmt --check
+      - name: checkout and env setup
+        uses: actions/checkout@v3
 
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust_version == 'default' && 'stable' || matrix.rust_version }}
+          components: rustfmt, clippy
+
+      - name: setup rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Test all features
+        run: cargo test --workspace --all-features
+
+      - name: Check no default features
+        run: cargo check --no-default-features --workspace
+
+      - name: Check `fs` feature (edgedb-tokio)
+        run: cargo check --features=fs --package edgedb-tokio
+
+      - name: Check with env feature, edgedb-tokio
+        run: cargo check --features=env --package edgedb-tokio
+
+      - name: Test edgedb-protocol without default features
+        run: cargo test --package=edgedb-protocol --no-default-features
+
+      - name: Test edgedb-protocol with "all-types" feature
+        run: cargo test --package=edgedb-protocol --features=all-types
+
+      - name: Run clippy
+        run: cargo clippy --workspace --all-features --all-targets
+
+      - name: Check formatting
+        run: cargo fmt --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,11 @@ jobs:
           toolchain: ${{ matrix.rust_version == 'default' && 'stable' || matrix.rust_version }}
           components: rustfmt, clippy
 
-      - name: Install EdgeDB
+      - name: Install EdgeDB CLI
         run: bash <(curl --proto '=https' --tlsv1.2 -sSf https://sh.edgedb.com) --nightly -y
+
+      - name: Install EdgeDB
+        run: edgedb server install --nightly
 
       - name: setup rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
           toolchain: ${{ matrix.rust_version == 'default' && 'stable' || matrix.rust_version }}
           components: rustfmt, clippy
 
+      - name: Install EdgeDB
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.edgedb.com | sh
+
       - name: setup rust cache
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install EdgeDB
         run: edgedb server install --nightly
 
+      - name: Link nightly
+        run: ln -s `edgedb server info --channel=nightly --get bin-path` ~/.local/bin/edgedb-server
+
       - name: Show binaries
         run: ls -l ~/.local/bin
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,17 +18,20 @@ jobs:
       - name: checkout and env setup
         uses: actions/checkout@v3
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust_version == 'default' && 'stable' || matrix.rust_version }}
-          components: rustfmt, clippy
-
       - name: Install EdgeDB CLI
         run: bash <(curl --proto '=https' --tlsv1.2 -sSf https://sh.edgedb.com) --nightly -y
 
       - name: Install EdgeDB
         run: edgedb server install --nightly
+
+      - name: Show binaries
+        run: ls -l ~/.local/bin
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust_version == 'default' && 'stable' || matrix.rust_version }}
+          components: rustfmt, clippy
 
       - name: setup rust cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
`nix` is far too slow and over-complicates this build process. We can just use the environment of the runner as-is.