### PR TITLE
Support both GEL_ and EDGEDB_ vars

### DIFF
--- a/edgedb-tokio/src/env.rs
+++ b/edgedb-tokio/src/env.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::io;
 use std::num::NonZeroU16;
 use std::time::Duration;
@@ -144,48 +145,6 @@ define_env!(
     #[env(GEL_WAIT_UNTIL_AVAILABLE, EDGEDB_WAIT_UNTIL_AVAILABLE)]
     #[parse=parse_duration]
     wait_until_available: Duration,
-    // // Print the analyze debug JSON.
-    // _ANALYZE_DEBUG_JSON: bool,
-
-    // // Print the debug plan.
-    // _ANALYZE_DEBUG_PLAN: bool,
-
-    // EDITOR: String,
-
-    // _FROM_WINDOWS: String,
-
-    // PAGER: String,
-    // PKG_ROOT: String,
-    // RUN_VERSION_CHECK: String,
-
-    // // Path to the server dev directory.
-    // SERVER_DEV_DIR: PathBuf,
-
-    // /// The path to the lock file for the server. Passed to the server.
-    // SERVER_EXTERNAL_LOCK_FD: String,
-
-    // /// The security mode for the HTTP endpoint. Passed to the server.
-    // SERVER_HTTP_ENDPOINT_SECURITY: String,
-
-    // /// The name of the instance.
-    // SERVER_INSTANCE_NAME: String,
-
-    // /// The log level for the server. Passed to the server.
-    // SERVER_LOG_LEVEL: String,
-
-    // TEST_BIN_EXE: String,
-
-    // _WSL_DISTRO: String,
-    // _WSL_LINUX_BINARY: String,
-
-    // INSTALL_IN_DOCKER: String,
-
-    // CLOUD_API_ENDPOINT: String,
-    // CLOUD_API_TIMEOUT: String,
-    // CLOUD_API_VERSION: String,
-    // CLOUD_DEFAULT_DNS_ZONE: String,
-    // CLOUD_SECRET_KEY: String,
-
 );
 
 fn ignore_docker_tcp_port(s: String) -> Option<String> {
@@ -212,11 +171,14 @@ fn non_empty_string(var: &str, s: &str) -> Result<(), Error> {
     }
 }
 
-fn parse<T: FromStr>(var: &str, s: &str) -> Result<T, Error> {
+fn parse<T: FromStr>(var: &str, s: &str) -> Result<T, Error>
+where
+    <T as FromStr>::Err: Debug,
+{
     Ok(s.parse().map_err(|e| {
         ClientError::with_source(io::Error::new(
             io::ErrorKind::InvalidInput,
-            format!("invalid {var} value: {s}"),
+            format!("invalid {var} value: {s}: {e:?}"),
         ))
     })?)
 }
@@ -235,14 +197,14 @@ fn parse_duration(var: &str, s: &str) -> Result<Duration, Error> {
     let duration = model::Duration::from_str(s).map_err(|e| {
         ClientError::with_source(io::Error::new(
             io::ErrorKind::InvalidInput,
-            format!("invalid {var} value: {s}"),
+            format!("invalid {var} value: {s}: {e:?}"),
         ))
     })?;
 
     duration.try_into().map_err(|e| {
         ClientError::with_source(io::Error::new(
             io::ErrorKind::InvalidInput,
-            format!("invalid {var} value: {s}"),
+            format!("invalid {var} value: {s}: {e:?}"),
         ))
     })
 }

--- a/edgedb-tokio/src/env.rs
+++ b/edgedb-tokio/src/env.rs
@@ -26,6 +26,7 @@ macro_rules! define_env {
 
         impl Env {
             $(
+                #[doc = $doc]
                 pub fn $name() -> ::std::result::Result<::std::option::Option<$type>, $crate::Error> {
                     const ENV_NAMES: &[&str] = &[$(stringify!($env_name)),+];
                     let Some((name, s)) = $crate::env::get_envs(ENV_NAMES)? else {

--- a/edgedb-tokio/src/env.rs
+++ b/edgedb-tokio/src/env.rs
@@ -10,6 +10,7 @@ use url::Url;
 use crate::errors::{ClientError, Error, ErrorKind};
 use crate::{builder::CloudCerts, ClientSecurity, InstanceName, TlsSecurity};
 
+#[cfg_attr(feature = "unstable", macro_export)]
 macro_rules! define_env {
     ($(
         #[doc=$doc:expr]
@@ -25,7 +26,7 @@ macro_rules! define_env {
 
         impl Env {
             $(
-                pub fn $name() -> ::std::result::Result<::std::option::Option<$type>, $crate::errors::Error> {
+                pub fn $name() -> ::std::result::Result<::std::option::Option<$type>, $crate::Error> {
                     const ENV_NAMES: &[&str] = &[$(stringify!($env_name)),+];
                     let Some((name, s)) = $crate::env::get_envs(ENV_NAMES)? else {
                         return Ok(None);
@@ -166,7 +167,8 @@ fn validate_host(var: &str, s: &str) -> Result<(), Error> {
 }
 
 #[inline(never)]
-fn parse<T: FromStr>(var: &str, s: &str) -> Result<T, Error>
+#[doc(hidden)]
+pub fn parse<T: FromStr>(var: &str, s: &str) -> Result<T, Error>
 where
     <T as FromStr>::Err: Debug,
 {
@@ -184,7 +186,9 @@ pub(crate) fn get_env(name: &str) -> Result<Option<String>, Error> {
     }
 }
 
-fn get_envs(names: &'static [&'static str]) -> Result<Option<(&'static str, String)>, Error> {
+#[inline(never)]
+#[doc(hidden)]
+pub fn get_envs(names: &'static [&'static str]) -> Result<Option<(&'static str, String)>, Error> {
     let mut name;
     let mut value = None;
     for n in names {

--- a/edgedb-tokio/src/env.rs
+++ b/edgedb-tokio/src/env.rs
@@ -1,0 +1,248 @@
+use std::io;
+use std::num::NonZeroU16;
+use std::time::Duration;
+use std::{env, path::PathBuf, str::FromStr};
+
+use edgedb_protocol::model;
+use url::Url;
+
+use crate::errors::{ClientError, Error, ErrorKind};
+use crate::{builder::CloudCerts, ClientSecurity, InstanceName, TlsSecurity};
+
+macro_rules! define_env {
+    ($(
+        #[doc=$doc:expr]
+        #[env($($env_name:expr),+)]
+        $(#[preprocess=$preprocess:expr])?
+        $(#[parse=$parse:expr])?
+        $(#[validate=$validate:expr])?
+        $name:ident: $type:ty
+    ),* $(,)?) => {
+        #[derive(Debug, Clone)]
+        pub struct Env {
+        }
+
+        impl Env {
+            $(
+                pub fn $name() -> ::std::result::Result<::std::option::Option<$type>, $crate::errors::Error> {
+                    let mut name;
+                    let mut value = None;
+                    $(
+                        let env_name = stringify!($env_name);
+                        name = env_name;
+                        if let Some(s) = $crate::env::get_env(env_name)? {
+                            if value.is_some() {
+                                return Err($crate::errors::ClientError::with_source(
+                                    ::std::io::Error::new(
+                                        ::std::io::ErrorKind::InvalidInput,
+                                        format!("multiple environment variables with the same name: {env_name}, {name}"),
+                                    ),
+                                ));
+                            }
+                            value = Some(s);
+                        };
+                    )+
+                    let Some(s) = value else {
+                        return Ok(None);
+                    };
+                    $(let Some(s) = $preprocess(s) else {
+                        return Ok(None);
+                    };)?
+                    #[allow(unused_labels)]
+                    let value: $type = 'block: {
+                        $(
+                            break 'block $parse(&name, &s)?;
+
+                            // Disable the fallback parser
+                            #[cfg(all(debug_assertions, not(debug_assertions)))]
+                        )?
+                        $crate::env::parse(&name, &s)?
+                    };
+
+                    $($validate(name, &value)?;)?
+                    Ok(Some(value))
+                }
+            )*
+        }
+    };
+}
+
+define_env!(
+    /// The host to connect to.
+    #[env(GEL_HOST, EDGEDB_HOST)]
+    host: String,
+
+    /// The port to connect to.
+    #[env(GEL_PORT, EDGEDB_PORT)]
+    #[preprocess=ignore_docker_tcp_port]
+    port: NonZeroU16,
+
+    /// The database name to connect to.
+    #[env(GEL_DATABASE, EDGEDB_DATABASE)]
+    #[validate=non_empty_string]
+    database: String,
+
+    /// The branch name to connect to.
+    #[env(GEL_BRANCH, EDGEDB_BRANCH)]
+    #[validate=non_empty_string]
+    branch: String,
+
+    /// The username to connect as.
+    #[env(GEL_USER, EDGEDB_USER)]
+    #[validate=non_empty_string]
+    user: String,
+
+    /// The password to use for authentication.
+    #[env(GEL_PASSWORD, EDGEDB_PASSWORD)]
+    password: String,
+
+    /// TLS server name to verify.
+    #[env(GEL_TLS_SERVER_NAME, EDGEDB_TLS_SERVER_NAME)]
+    tls_server_name: String,
+
+    /// Path to credentials file.
+    #[env(GEL_CREDENTIALS_FILE, EDGEDB_CREDENTIALS_FILE)]
+    credentials_file: String,
+
+    /// Instance name to connect to.
+    #[env(GEL_INSTANCE, EDGEDB_INSTANCE)]
+    instance: InstanceName,
+
+    /// Connection DSN string.
+    #[env(GEL_DSN, EDGEDB_DSN)]
+    dsn: Url,
+
+    /// Secret key for authentication.
+    #[env(GEL_SECRET_KEY, EDGEDB_SECRET_KEY)]
+    secret_key: String,
+
+    /// Client security mode.
+    #[env(GEL_CLIENT_SECURITY, EDGEDB_CLIENT_SECURITY)]
+    client_security: ClientSecurity,
+
+    /// TLS security mode.
+    #[env(GEL_CLIENT_TLS_SECURITY, EDGEDB_CLIENT_TLS_SECURITY)]
+    client_tls_security: TlsSecurity,
+
+    /// Path to TLS CA certificate file.
+    #[env(GEL_TLS_CA, EDGEDB_TLS_CA)]
+    tls_ca: String,
+
+    /// Path to TLS CA certificate file.
+    #[env(GEL_TLS_CA_FILE, EDGEDB_TLS_CA_FILE)]
+    tls_ca_file: PathBuf,
+
+    /// Cloud profile name.
+    #[env(GEL_CLOUD_PROFILE, EDGEDB_CLOUD_PROFILE)]
+    cloud_profile: String,
+
+    /// Cloud certificates mode.
+    #[env(_GEL_CLOUD_CERTS, _EDGEDB_CLOUD_CERTS)]
+    _cloud_certs: CloudCerts,
+
+    /// How long to wait for server to become available.
+    #[env(GEL_WAIT_UNTIL_AVAILABLE, EDGEDB_WAIT_UNTIL_AVAILABLE)]
+    #[parse=parse_duration]
+    wait_until_available: Duration,
+    // // Print the analyze debug JSON.
+    // _ANALYZE_DEBUG_JSON: bool,
+
+    // // Print the debug plan.
+    // _ANALYZE_DEBUG_PLAN: bool,
+
+    // EDITOR: String,
+
+    // _FROM_WINDOWS: String,
+
+    // PAGER: String,
+    // PKG_ROOT: String,
+    // RUN_VERSION_CHECK: String,
+
+    // // Path to the server dev directory.
+    // SERVER_DEV_DIR: PathBuf,
+
+    // /// The path to the lock file for the server. Passed to the server.
+    // SERVER_EXTERNAL_LOCK_FD: String,
+
+    // /// The security mode for the HTTP endpoint. Passed to the server.
+    // SERVER_HTTP_ENDPOINT_SECURITY: String,
+
+    // /// The name of the instance.
+    // SERVER_INSTANCE_NAME: String,
+
+    // /// The log level for the server. Passed to the server.
+    // SERVER_LOG_LEVEL: String,
+
+    // TEST_BIN_EXE: String,
+
+    // _WSL_DISTRO: String,
+    // _WSL_LINUX_BINARY: String,
+
+    // INSTALL_IN_DOCKER: String,
+
+    // CLOUD_API_ENDPOINT: String,
+    // CLOUD_API_TIMEOUT: String,
+    // CLOUD_API_VERSION: String,
+    // CLOUD_DEFAULT_DNS_ZONE: String,
+    // CLOUD_SECRET_KEY: String,
+
+);
+
+fn ignore_docker_tcp_port(s: String) -> Option<String> {
+    static PORT_WARN: std::sync::Once = std::sync::Once::new();
+
+    if s.starts_with("tcp://") {
+        PORT_WARN.call_once(|| {
+            eprintln!("GEL_PORT/EDGEDB_PORT is ignored when using Docker TCP port");
+        });
+        None
+    } else {
+        Some(s)
+    }
+}
+
+fn non_empty_string(var: &str, s: &str) -> Result<(), Error> {
+    if s.is_empty() {
+        Err(ClientError::with_source(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid {var} value: {s}"),
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn parse<T: FromStr>(var: &str, s: &str) -> Result<T, Error> {
+    Ok(s.parse().map_err(|e| {
+        ClientError::with_source(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid {var} value: {s}"),
+        ))
+    })?)
+}
+
+pub(crate) fn get_env(name: &str) -> Result<Option<String>, Error> {
+    match env::var(name) {
+        Ok(v) if v.is_empty() => Ok(None),
+        Ok(v) => Ok(Some(v)),
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(e) => Err(ClientError::with_source(e)
+            .context(format!("Cannot decode environment variable {:?}", name))),
+    }
+}
+
+fn parse_duration(var: &str, s: &str) -> Result<Duration, Error> {
+    let duration = model::Duration::from_str(s).map_err(|e| {
+        ClientError::with_source(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid {var} value: {s}"),
+        ))
+    })?;
+
+    duration.try_into().map_err(|e| {
+        ClientError::with_source(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid {var} value: {s}"),
+        ))
+    })
+}

--- a/edgedb-tokio/src/env.rs
+++ b/edgedb-tokio/src/env.rs
@@ -189,21 +189,25 @@ pub(crate) fn get_env(name: &str) -> Result<Option<String>, Error> {
 #[inline(never)]
 #[doc(hidden)]
 pub fn get_envs(names: &'static [&'static str]) -> Result<Option<(&'static str, String)>, Error> {
-    let mut name;
     let mut value = None;
-    for n in names {
-        name = n;
-        if let Some(s) = get_env(name)? {
-            if value.is_some() {
-                log::warn!(
-                    "multiple environment variables with the same name: {}",
-                    names.join(", ")
-                );
-            } else {
-                value = Some((*name, s));
+    let mut found_vars = Vec::new();
+    
+    for name in names {
+        if let Some(val) = get_env(name)? {
+            found_vars.push(format!("{}={}", name, val));
+            if value.is_none() {
+                value = Some((*name, val));
             }
         }
     }
+
+    if found_vars.len() > 1 {
+        log::warn!(
+            "Multiple environment variables set: {}",
+            found_vars.join(", ")
+        );
+    }
+
     Ok(value)
 }
 

--- a/edgedb-tokio/src/lib.rs
+++ b/edgedb-tokio/src/lib.rs
@@ -119,6 +119,8 @@ pub mod raw;
 pub mod server_params;
 #[cfg(feature = "unstable")]
 pub mod tls;
+#[cfg(feature = "unstable")]
+pub mod env;
 
 #[cfg(not(feature = "unstable"))]
 mod credentials;
@@ -128,13 +130,11 @@ mod raw;
 mod server_params;
 #[cfg(not(feature = "unstable"))]
 mod tls;
+#[cfg(not(feature = "unstable"))]
+mod env;
 
 mod builder;
 mod client;
-#[cfg(feature = "unstable")]
-pub mod env;
-#[cfg(not(feature = "unstable"))]
-mod env;
 mod errors;
 mod options;
 mod query_executor;

--- a/edgedb-tokio/src/lib.rs
+++ b/edgedb-tokio/src/lib.rs
@@ -111,29 +111,28 @@ reader.
     warn(missing_docs, missing_debug_implementations)
 )]
 
-#[cfg(feature = "unstable")]
-pub mod credentials;
-#[cfg(feature = "unstable")]
-pub mod raw;
-#[cfg(feature = "unstable")]
-pub mod server_params;
-#[cfg(feature = "unstable")]
-pub mod tls;
-#[cfg(feature = "unstable")]
-pub mod env;
+macro_rules! unstable_pub_mods {
+    ($(mod $mod_name:ident;)*) => {
+        $(
+            #[cfg(feature = "unstable")]
+            pub mod $mod_name;
+            #[cfg(not(feature = "unstable"))]
+            mod $mod_name;
+        )*
+    }
+}
 
-#[cfg(not(feature = "unstable"))]
-mod credentials;
-#[cfg(not(feature = "unstable"))]
-mod raw;
-#[cfg(not(feature = "unstable"))]
-mod server_params;
-#[cfg(not(feature = "unstable"))]
-mod tls;
-#[cfg(not(feature = "unstable"))]
-mod env;
+// If the unstable feature is enabled, the modules will be public.
+// If the unstable feature is not enabled, the modules will be private.
+unstable_pub_mods! {
+    mod builder;
+    mod credentials;
+    mod raw;
+    mod server_params;
+    mod tls;
+    mod env;
+}
 
-mod builder;
 mod client;
 mod errors;
 mod options;

--- a/edgedb-tokio/src/lib.rs
+++ b/edgedb-tokio/src/lib.rs
@@ -131,6 +131,9 @@ mod tls;
 
 mod builder;
 mod client;
+#[cfg(feature = "unstable")]
+pub mod env;
+#[cfg(not(feature = "unstable"))]
 mod env;
 mod errors;
 mod options;

--- a/edgedb-tokio/src/lib.rs
+++ b/edgedb-tokio/src/lib.rs
@@ -131,6 +131,7 @@ mod tls;
 
 mod builder;
 mod client;
+mod env;
 mod errors;
 mod options;
 mod query_executor;


### PR DESCRIPTION
This allows `edgedb-cli` to pass all of the shared testcases. To simplify this logic we extract most of the env-var parsing to `env.rs`. This isn't a full cleanup of this code, but it makes it a little easier to parse what's going on.

Long term we'll need to untangle this error parsing code as it's quite complex and hard to follow. 

There's a bit of code here where we need to "lie" that the configuration is complete when we find errors in the environment variables themselves. Ideally this would be done when we surface the errors instead, but that's a more complicated lift.