### PR TITLE
Add support for Standalone transactions and explicit commits and rollbacks

### DIFF
--- a/edgedb-protocol/tests/codecs.rs
+++ b/edgedb-protocol/tests/codecs.rs
@@ -4,7 +4,7 @@ extern crate pretty_assertions;
 use std::error::Error;
 use std::sync::Arc;
 
-use bytes::{Buf, Bytes};
+use bytes::Bytes;
 
 use edgedb_protocol::codec::build_codec;
 use edgedb_protocol::codec::{Codec, ObjectShape};

--- a/edgedb-tokio/tests/func/transactions.rs
+++ b/edgedb-tokio/tests/func/transactions.rs
@@ -31,7 +31,7 @@ async fn transaction1(
     lock: Arc<Mutex<()>>,
 ) -> anyhow::Result<i32> {
     let val = client
-        .transaction(|mut tx| {
+        .retryable_transaction(|mut tx| {
             let lock = lock.clone();
             let iterations = iterations.clone();
             let barrier = barrier.clone();
@@ -118,7 +118,7 @@ async fn transaction1e(
     lock: Arc<Mutex<()>>,
 ) -> anyhow::Result<i32> {
     let val = client
-        .transaction(|mut tx| {
+        .retryable_transaction(|mut tx| {
             let lock = lock.clone();
             let iterations = iterations.clone();
             let barrier = barrier.clone();
@@ -163,7 +163,7 @@ async fn transaction_conflict_with_complex_err() -> anyhow::Result<()> {
 async fn queries() -> anyhow::Result<()> {
     let client = Client::new(&SERVER.config);
     client
-        .transaction(|mut tx| async move {
+        .retryable_transaction(|mut tx| async move {
             let value = tx.query::<i64, _>("SELECT 7*93", &()).await?;
             assert_eq!(value, vec![651]);
 


### PR DESCRIPTION
Adds support for explicit user commits and rollbacks, while still allowing retryable transactions. Also allows users to rollback in retryable transactions, albeit the user now has to explicitly commit them too.

```rust
async fn retryable_transaction() -> Result<(), edgedb_tokio::Error> {
    let conn = edgedb_tokio::create_client().await?;
    let val = conn
        .retryable_transaction(|mut tx| async move {
            let new_value = tx
                .query_required_single::<i64, _>(
                    "
                    WITH C := UPDATE Counter SET { value := .value + 1}
                    SELECT C.value LIMIT 1
                    ",
                    &(),
                )
                .await?;
            tx.commit().await?;
            Ok(new_value)
        })
        .await?;
    Ok(())
}
```

Standalone transactions:

```rust
async fn transaction() -> Result<(), edgedb_tokio::Error> {
    let conn = edgedb_tokio::create_client().await?;
    let mut tx = conn.transaction().await?;
    let new_value = tx
        .query_required_single::<i64, _>(
            "
        WITH C := UPDATE Counter SET { value := .value + 1}
        SELECT C.value LIMIT 1
    ",
            &(),
        )
        .await?;
    tx.commit().await?;
    Ok(())
}
```

Closes: https://github.com/edgedb/edgedb-rust/issues/369