### PR TITLE
Raw transactions

### DIFF
--- a/gel-tokio/src/client.rs
+++ b/gel-tokio/src/client.rs
@@ -16,7 +16,7 @@ use crate::raw::{Options, PoolState, Response};
 use crate::raw::{Pool, QueryCapabilities};
 use crate::state::{AliasesDelta, ConfigDelta, GlobalsDelta};
 use crate::state::{AliasesModifier, ConfigModifier, Fn, GlobalsModifier};
-use crate::transaction::{RawTransaction, RetryingTransaction};
+use crate::transaction;
 use crate::ResultVerbose;
 
 /// Gel database client.
@@ -416,10 +416,10 @@ impl Client {
     /// ```
     pub async fn transaction<T, B, F>(&self, body: B) -> Result<T, Error>
     where
-        B: FnMut(RetryingTransaction) -> F,
+        B: FnMut(transaction::RetryingTransaction) -> F,
         F: Future<Output = Result<T, Error>>,
     {
-        crate::transaction::run_and_retry(&self.pool, self.options.clone(), body).await
+        transaction::run_and_retry(&self.pool, self.options.clone(), body).await
     }
 
     /// Start a transaction without the retry mechanism.
@@ -447,8 +447,8 @@ impl Client {
     /// # Example
     ///
     /// ```rust,no_run
-    /// # async fn main_() -> Result<(), edgedb_tokio::Error> {
-    /// let conn = edgedb_tokio::create_client().await?;
+    /// # async fn main_() -> Result<(), gel_tokio::Error> {
+    /// let conn = gel_tokio::create_client().await?;
     /// let mut tx = conn.transaction_raw().await?;
     /// tx.query_required_single::<i64, _>("
     ///     WITH C := UPDATE Counter SET { value := .value + 1}
@@ -459,7 +459,8 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn transaction_raw(&self) -> Result<RawTransaction, Error> {
+    #[cfg(feature = "unstable")]
+    pub async fn transaction_raw(&self) -> Result<transaction::RawTransaction, Error> {
         crate::transaction::start(&self.pool, self.options.clone()).await
     }
 

--- a/gel-tokio/src/lib.rs
+++ b/gel-tokio/src/lib.rs
@@ -151,7 +151,7 @@ pub use errors::Error;
 pub use options::{RetryCondition, RetryOptions, TransactionOptions};
 pub use query_executor::{QueryExecutor, ResultVerbose};
 pub use state::{ConfigDelta, GlobalsDelta};
-pub use transaction::{RawTransaction, RetryingTransaction, Transaction};
+pub use transaction::{RetryingTransaction, Transaction};
 
 /// The ordered list of project filenames supported.
 pub const PROJECT_FILES: &[&str] = &["gel.toml", "edgedb.toml"];
@@ -161,6 +161,8 @@ pub const DEFAULT_PROJECT_FILE: &str = PROJECT_FILES[0];
 
 #[cfg(feature = "unstable")]
 pub use builder::{get_project_path, get_stash_path};
+#[cfg(feature = "unstable")]
+pub use transaction::RawTransaction;
 
 /// Create a connection to the database with default parameters
 ///

--- a/gel-tokio/src/lib.rs
+++ b/gel-tokio/src/lib.rs
@@ -151,7 +151,7 @@ pub use errors::Error;
 pub use options::{RetryCondition, RetryOptions, TransactionOptions};
 pub use query_executor::{QueryExecutor, ResultVerbose};
 pub use state::{ConfigDelta, GlobalsDelta};
-pub use transaction::Transaction;
+pub use transaction::{RawTransaction, RetryingTransaction, Transaction};
 
 /// The ordered list of project filenames supported.
 pub const PROJECT_FILES: &[&str] = &["gel.toml", "edgedb.toml"];

--- a/gel-tokio/src/query_executor.rs
+++ b/gel-tokio/src/query_executor.rs
@@ -29,7 +29,7 @@ pub trait QueryExecutor: Sized {
         A: QueryArgs,
         R: QueryResult + Send;
 
-    /// see [Client::query_with_warnings]
+    /// see [Client::query_verbose]
     fn query_verbose<R, A>(
         self,
         query: impl AsRef<str> + Send,
@@ -171,7 +171,7 @@ impl QueryExecutor for &Client {
     }
 }
 
-impl QueryExecutor for &mut Transaction {
+impl<T: std::ops::DerefMut<Target = Transaction>> QueryExecutor for &mut T {
     fn query<R, A>(
         self,
         query: impl AsRef<str> + Send,

--- a/gel-tokio/src/transaction.rs
+++ b/gel-tokio/src/transaction.rs
@@ -39,10 +39,12 @@ pub struct Transaction {
 /// All database queries in transaction should be executed using methods on
 /// this object instead of using original [`Client`](crate::Client) instance.
 #[derive(Debug)]
+#[cfg(feature = "unstable")]
 pub struct RawTransaction {
     inner: Option<Transaction>,
 }
 
+#[cfg(feature = "unstable")]
 impl RawTransaction {
     /// Commit the transaction.
     ///
@@ -68,6 +70,7 @@ impl RawTransaction {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl std::ops::Deref for RawTransaction {
     type Target = Transaction;
 
@@ -76,12 +79,14 @@ impl std::ops::Deref for RawTransaction {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl std::ops::DerefMut for RawTransaction {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.inner.as_mut().unwrap()
     }
 }
 
+#[cfg(feature = "unstable")]
 impl Drop for RawTransaction {
     fn drop(&mut self) {
         if let Some(tran) = self.inner.take() {
@@ -90,6 +95,7 @@ impl Drop for RawTransaction {
     }
 }
 
+#[cfg(feature = "unstable")]
 pub(crate) async fn start(pool: &Pool, options: Arc<Options>) -> Result<RawTransaction, Error> {
     let conn = pool.acquire().await?;
 

--- a/gel-tokio/tests/func/dbschema/test.esdl
+++ b/gel-tokio/tests/func/dbschema/test.esdl
@@ -21,4 +21,8 @@ module test {
         required sent_at: datetime;
         confirmed_at: datetime;
     }
+
+    type X {
+        a: str;
+    }
 }

--- a/gel-tokio/tests/func/dbschema/test.esdl
+++ b/gel-tokio/tests/func/dbschema/test.esdl
@@ -25,4 +25,8 @@ module test {
     type X {
         a: str;
     }
+
+    type Y {
+        a: str;
+    }
 }


### PR DESCRIPTION
Closes #369
Supersedes #370

Adds the following API:

```rust
impl Client {
    fn transaction() -> Result<StandaloneTransaction, Error>;

    fn within_transaction(body: FnMut(RetryingTransaction) -> Future<...>) -> Result<...>;
}

impl Drop for StandaloneTransaction {
    fn drop(&mut self) {
        self.rollback();
    }
}
```

Both `RetryingTransaction` and `StandaloneTransaction`  implement `DerefMut<Target = Transaction>`, which gives access to all `query_*` and `execute` methods that reside on the `Transaction`.

