### PR TITLE
Add Queryable::Args which hold decoing arguments

### DIFF
--- a/gel-derive/src/enums.rs
+++ b/gel-derive/src/enums.rs
@@ -22,6 +22,8 @@ pub fn derive_enum(s: &syn::ItemEnum) -> syn::Result<TokenStream> {
     let expanded = quote! {
         impl #impl_generics ::gel_protocol::queryable::Queryable
             for #type_name #ty_generics {
+            type Args = ();
+
             fn decode(decoder: &::gel_protocol::queryable::Decoder, buf: &[u8])
                 -> Result<Self, ::gel_protocol::errors::DecodeError>
             {

--- a/gel-derive/src/enums.rs
+++ b/gel-derive/src/enums.rs
@@ -24,7 +24,7 @@ pub fn derive_enum(s: &syn::ItemEnum) -> syn::Result<TokenStream> {
             for #type_name #ty_generics {
             type Args = ();
 
-            fn decode(decoder: &::gel_protocol::queryable::Decoder, buf: &[u8])
+            fn decode(decoder: &::gel_protocol::queryable::Decoder, _args: &(), buf: &[u8])
                 -> Result<Self, ::gel_protocol::errors::DecodeError>
             {
                 match buf {

--- a/gel-derive/src/json.rs
+++ b/gel-derive/src/json.rs
@@ -21,6 +21,8 @@ pub fn derive(item: &syn::Item) -> syn::Result<TokenStream> {
     let expanded = quote! {
         impl #impl_generics ::gel_protocol::queryable::Queryable
             for #name #ty_generics {
+            type Args = ();
+
             fn decode(decoder: &::gel_protocol::queryable::Decoder, buf: &[u8])
                 -> Result<Self, ::gel_protocol::errors::DecodeError>
             {

--- a/gel-derive/src/json.rs
+++ b/gel-derive/src/json.rs
@@ -23,11 +23,11 @@ pub fn derive(item: &syn::Item) -> syn::Result<TokenStream> {
             for #name #ty_generics {
             type Args = ();
 
-            fn decode(decoder: &::gel_protocol::queryable::Decoder, buf: &[u8])
+            fn decode(decoder: &::gel_protocol::queryable::Decoder, _args: &(), buf: &[u8])
                 -> Result<Self, ::gel_protocol::errors::DecodeError>
             {
                 let json: ::gel_protocol::model::Json =
-                    ::gel_protocol::queryable::Queryable::decode(decoder, buf)?;
+                    ::gel_protocol::queryable::Queryable::decode(decoder, &(), buf)?;
                 ::serde_json::from_str(json.as_ref())
                     .map_err(::gel_protocol::errors::decode_error)
             }

--- a/gel-derive/src/shape.rs
+++ b/gel-derive/src/shape.rs
@@ -89,7 +89,7 @@ pub fn derive_struct(s: &syn::ItemStruct) -> syn::Result<TokenStream> {
                     let #fieldname: ::gel_protocol::model::Json =
                         <::gel_protocol::model::Json as
                             ::gel_protocol::queryable::Queryable>
-                        ::decode_optional(#decoder, #elements.read()?)?;
+                        ::decode_optional(#decoder, &(), #elements.read()?)?;
                     let #fieldname = ::serde_json::from_str(#fieldname.as_ref())
                         .map_err(::gel_protocol::errors::decode_error)?;
                 }
@@ -97,7 +97,7 @@ pub fn derive_struct(s: &syn::ItemStruct) -> syn::Result<TokenStream> {
                 quote! {
                     let #fieldname =
                         ::gel_protocol::queryable::Queryable
-                        ::decode_optional(#decoder, #elements.read()?)?;
+                        ::decode_optional(#decoder, &(), #elements.read()?)?;
                 }
             }
         })
@@ -137,7 +137,7 @@ pub fn derive_struct(s: &syn::ItemStruct) -> syn::Result<TokenStream> {
             for #name #ty_generics {
             type Args = ();
 
-            fn decode(#decoder: &::gel_protocol::queryable::Decoder, #buf: &[u8])
+            fn decode(#decoder: &::gel_protocol::queryable::Decoder, _args: &(), #buf: &[u8])
                 -> ::std::result::Result<Self, ::gel_protocol::errors::DecodeError>
             {
                 let #nfields = #base_fields

--- a/gel-derive/src/shape.rs
+++ b/gel-derive/src/shape.rs
@@ -135,6 +135,8 @@ pub fn derive_struct(s: &syn::ItemStruct) -> syn::Result<TokenStream> {
     let expanded = quote! {
         impl #impl_generics ::gel_protocol::queryable::Queryable
             for #name #ty_generics {
+            type Args = ();
+
             fn decode(#decoder: &::gel_protocol::queryable::Decoder, #buf: &[u8])
                 -> ::std::result::Result<Self, ::gel_protocol::errors::DecodeError>
             {

--- a/gel-derive/tests/enums.rs
+++ b/gel-derive/tests/enums.rs
@@ -11,14 +11,17 @@ enum Status {
 #[test]
 fn enumeration() {
     let dec = Decoder::default();
-    assert_eq!(Status::decode(&dec, &b"Open"[..]).unwrap(), Status::Open);
     assert_eq!(
-        Status::decode(&dec, &b"Closed"[..]).unwrap(),
+        Status::decode(&dec, &(), &b"Open"[..]).unwrap(),
+        Status::Open
+    );
+    assert_eq!(
+        Status::decode(&dec, &(), &b"Closed"[..]).unwrap(),
         Status::Closed
     );
     assert_eq!(
-        Status::decode(&dec, &b"Invalid"[..]).unwrap(),
+        Status::decode(&dec, &(), &b"Invalid"[..]).unwrap(),
         Status::Invalid
     );
-    Status::decode(&dec, &b"closed"[..]).unwrap_err();
+    Status::decode(&dec, &(), &b"closed"[..]).unwrap_err();
 }

--- a/gel-derive/tests/json.rs
+++ b/gel-derive/tests/json.rs
@@ -34,7 +34,7 @@ fn json_field() {
         \0\0\x0b\x86\0\0\0\x10\xf2\xe6F9\xd7\x04\x11\xea\
         \xa0<\x83\x9f\xd9\xbd\x88\x94\0\0\0\x19\
         \0\0\0\x02id\0\0\x0e\xda\0\0\0\x10\x01{\"field1\": 123}";
-    let res = ShapeWithJson::decode(&old_decoder(), data);
+    let res = ShapeWithJson::decode(&old_decoder(), &(), data);
     assert_eq!(
         res.unwrap(),
         ShapeWithJson {
@@ -47,6 +47,6 @@ fn json_field() {
 #[test]
 fn json_row() {
     let data = b"\x01{\"field2\": 234}";
-    let res = JsonRow::decode(&old_decoder(), data);
+    let res = JsonRow::decode(&old_decoder(), &(), data);
     assert_eq!(res.unwrap(), JsonRow { field2: 234 });
 }

--- a/gel-derive/tests/list_scalar_types.rs
+++ b/gel-derive/tests/list_scalar_types.rs
@@ -20,7 +20,7 @@ fn decode_new() {
     let data = b"\0\0\0\x03\0\0\0\x19\0\0\0\x0fcal::local_date\
                \0\0\0\x19\0\0\0 std::anyscalar, std::anydiscrete\
                \0\0\0\x19\0\0\0\x06normal";
-    let res = ScalarType::decode(&Decoder::default(), data);
+    let res = ScalarType::decode(&Decoder::default(), &(), data);
     assert_eq!(
         res.unwrap(),
         ScalarType {
@@ -38,7 +38,7 @@ fn decode_old() {
         \xee\xfc\xb6\x12\0\0\x0b\x86\0\0\0\x10\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
         \x01\x0c\0\0\0\x19\0\0\0\x0fcal::local_date\
         \0\0\0\x19\0\0\0\x0estd::anyscalar\0\0\0\x19\0\0\0\x06normal";
-    let res = ScalarType::decode(&old_decoder(), data);
+    let res = ScalarType::decode(&old_decoder(), &(), data);
     assert_eq!(
         res.unwrap(),
         ScalarType {

--- a/gel-derive/tests/varnames.rs
+++ b/gel-derive/tests/varnames.rs
@@ -14,7 +14,7 @@ fn decode() {
     let data = b"\0\0\0\x04\0\0\0\x14\0\0\0\x08\0\0\0\0\0\0\x03\0\0\0\
                   \0\x19\0\0\0\0\0\0\0\x19\0\0\0\x0bSomeDecoder\
                   \0\0\0\x14\0\0\0\x08\0\0\0\0\0\0\0{";
-    let res = WeirdStruct::decode(&Decoder::default(), data);
+    let res = WeirdStruct::decode(&Decoder::default(), &(), data);
     assert_eq!(
         res.unwrap(),
         WeirdStruct {

--- a/gel-protocol/src/model/vector.rs
+++ b/gel-protocol/src/model/vector.rs
@@ -29,6 +29,8 @@ impl DerefMut for Vector {
 }
 
 impl Queryable for Vector {
+    type Args = ();
+
     fn decode(_decoder: &Decoder, mut buf: &[u8]) -> Result<Self, DecodeError> {
         ensure!(buf.remaining() >= 4, errors::Underflow);
         let length = buf.get_u16() as usize;

--- a/gel-protocol/src/model/vector.rs
+++ b/gel-protocol/src/model/vector.rs
@@ -31,7 +31,7 @@ impl DerefMut for Vector {
 impl Queryable for Vector {
     type Args = ();
 
-    fn decode(_decoder: &Decoder, mut buf: &[u8]) -> Result<Self, DecodeError> {
+    fn decode(_decoder: &Decoder, _args: &(), mut buf: &[u8]) -> Result<Self, DecodeError> {
         ensure!(buf.remaining() >= 4, errors::Underflow);
         let length = buf.get_u16() as usize;
         let _reserved = buf.get_u16();

--- a/gel-protocol/src/queryable.rs
+++ b/gel-protocol/src/queryable.rs
@@ -19,6 +19,8 @@ pub struct Decoder {
 }
 
 pub trait Queryable: Sized {
+    type Args;
+
     fn decode(decoder: &Decoder, buf: &[u8]) -> Result<Self, DecodeError>;
     fn decode_optional(decoder: &Decoder, buf: Option<&[u8]>) -> Result<Self, DecodeError> {
         ensure!(buf.is_some(), errors::MissingRequiredElement);
@@ -27,7 +29,7 @@ pub trait Queryable: Sized {
     fn check_descriptor(
         ctx: &DescriptorContext,
         type_pos: TypePos,
-    ) -> Result<(), DescriptorMismatch>;
+    ) -> Result<Self::Args, DescriptorMismatch>;
 }
 
 #[derive(Snafu, Debug)]

--- a/gel-protocol/src/queryable.rs
+++ b/gel-protocol/src/queryable.rs
@@ -19,12 +19,19 @@ pub struct Decoder {
 }
 
 pub trait Queryable: Sized {
+    /// Data returned by [Queryable::check_descriptor], that can be used during decoding.
+    /// For example, this is used to pass the order of object pointers (which is sent in
+    /// type descriptors) to decode function.
     type Args;
 
-    fn decode(decoder: &Decoder, buf: &[u8]) -> Result<Self, DecodeError>;
-    fn decode_optional(decoder: &Decoder, buf: Option<&[u8]>) -> Result<Self, DecodeError> {
+    fn decode(decoder: &Decoder, args: &Self::Args, buf: &[u8]) -> Result<Self, DecodeError>;
+    fn decode_optional(
+        decoder: &Decoder,
+        args: &Self::Args,
+        buf: Option<&[u8]>,
+    ) -> Result<Self, DecodeError> {
         ensure!(buf.is_some(), errors::MissingRequiredElement);
-        Self::decode(decoder, buf.unwrap())
+        Self::decode(decoder, args, buf.unwrap())
     }
     fn check_descriptor(
         ctx: &DescriptorContext,

--- a/gel-protocol/src/serialization/decode/queryable/collections.rs
+++ b/gel-protocol/src/serialization/decode/queryable/collections.rs
@@ -6,6 +6,8 @@ use crate::serialization::decode::DecodeArrayLike;
 use std::iter::FromIterator;
 
 impl<T: Queryable> Queryable for Option<T> {
+    type Args = T::Args;
+
     fn decode(decoder: &Decoder, buf: &[u8]) -> Result<Self, DecodeError> {
         Ok(Some(T::decode(decoder, buf)?))
     }
@@ -17,7 +19,7 @@ impl<T: Queryable> Queryable for Option<T> {
     fn check_descriptor(
         ctx: &DescriptorContext,
         type_pos: TypePos,
-    ) -> Result<(), DescriptorMismatch> {
+    ) -> Result<T::Args, DescriptorMismatch> {
         T::check_descriptor(ctx, type_pos)
     }
 }
@@ -44,7 +46,7 @@ where
     fn check_descriptor(
         ctx: &DescriptorContext,
         type_pos: TypePos,
-    ) -> Result<(), DescriptorMismatch> {
+    ) -> Result<<<T as IntoIterator>::Item as Queryable>::Args, DescriptorMismatch> {
         let desc = ctx.get(type_pos)?;
         let element_type_pos = match desc {
             Descriptor::Set(desc) => desc.type_pos,
@@ -56,6 +58,8 @@ where
 }
 
 impl<T: Queryable> Queryable for Vec<T> {
+    type Args = T::Args;
+
     fn decode(decoder: &Decoder, buf: &[u8]) -> Result<Self, DecodeError> {
         Collection::<Vec<T>>::decode(decoder, buf)
     }
@@ -67,7 +71,7 @@ impl<T: Queryable> Queryable for Vec<T> {
     fn check_descriptor(
         ctx: &DescriptorContext,
         type_pos: TypePos,
-    ) -> Result<(), DescriptorMismatch> {
+    ) -> Result<T::Args, DescriptorMismatch> {
         Collection::<Vec<T>>::check_descriptor(ctx, type_pos)
     }
 }

--- a/gel-protocol/src/serialization/decode/queryable/scalars.rs
+++ b/gel-protocol/src/serialization/decode/queryable/scalars.rs
@@ -41,6 +41,8 @@ pub trait DecodeScalar: for<'a> RawCodec<'a> + Sized {
 }
 
 impl<T: DecodeScalar> Queryable for T {
+    type Args = ();
+
     fn decode(_decoder: &Decoder, buf: &[u8]) -> Result<Self, DecodeError> {
         RawCodec::decode(buf)
     }

--- a/gel-protocol/src/serialization/decode/queryable/scalars.rs
+++ b/gel-protocol/src/serialization/decode/queryable/scalars.rs
@@ -43,7 +43,7 @@ pub trait DecodeScalar: for<'a> RawCodec<'a> + Sized {
 impl<T: DecodeScalar> Queryable for T {
     type Args = ();
 
-    fn decode(_decoder: &Decoder, buf: &[u8]) -> Result<Self, DecodeError> {
+    fn decode(_decoder: &Decoder, _args: &(), buf: &[u8]) -> Result<Self, DecodeError> {
         RawCodec::decode(buf)
     }
     fn check_descriptor(

--- a/gel-protocol/src/serialization/decode/queryable/tuples.rs
+++ b/gel-protocol/src/serialization/decode/queryable/tuples.rs
@@ -5,7 +5,7 @@ use crate::queryable::{Decoder, DescriptorContext, Queryable};
 use crate::serialization::decode::DecodeTupleLike;
 
 macro_rules! implement_tuple {
-    ( $count:expr, $($name:ident,)+ ) => (
+    ( $count:expr, $(($name:ident, $index:tt),)+ ) => (
         impl<$($name:Queryable),+> Queryable for ($($name,)+) {
             type Args = (
                 $(
@@ -13,14 +13,14 @@ macro_rules! implement_tuple {
                 )+
             );
 
-            fn decode(decoder: &Decoder, buf: &[u8])
+            fn decode(decoder: &Decoder, args: &Self::Args, buf: &[u8])
                 -> Result<Self, DecodeError>
             {
                 let mut elements = DecodeTupleLike::new_tuple(buf, $count)?;
                 Ok((
                     $(
                         <$name as crate::queryable::Queryable>::
-                            decode_optional(decoder, elements.read()?)?,
+                            decode_optional(decoder, &args.$index, elements.read()?)?,
                     )+
                 ))
             }
@@ -46,15 +46,117 @@ macro_rules! implement_tuple {
     )
 }
 
-implement_tuple! {1, T0, }
-implement_tuple! {2, T0, T1, }
-implement_tuple! {3, T0, T1, T2, }
-implement_tuple! {4, T0, T1, T2, T3, }
-implement_tuple! {5, T0, T1, T2, T3, T4, }
-implement_tuple! {6, T0, T1, T2, T3, T4, T5, }
-implement_tuple! {7, T0, T1, T2, T3, T4, T5, T6, }
-implement_tuple! {8, T0, T1, T2, T3, T4, T5, T6, T7, }
-implement_tuple! {9, T0, T1, T2, T3, T4, T5, T6, T7, T8, }
-implement_tuple! {10, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, }
-implement_tuple! {11, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, }
-implement_tuple! {12, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, }
+implement_tuple! {
+    1,
+    (T0, 0),
+}
+implement_tuple! {
+    2,
+    (T0, 0),
+    (T1, 1),
+}
+implement_tuple! {
+    3,
+    (T0, 0),
+    (T1, 1),
+    (T2, 2),
+}
+implement_tuple! {
+    4,
+    (T0, 0),
+    (T1, 1),
+    (T2, 2),
+    (T3, 3),
+}
+implement_tuple! {
+    5,
+    (T0, 0),
+    (T1, 1),
+    (T2, 2),
+    (T3, 3),
+    (T4, 4),
+}
+implement_tuple! {
+    6,
+    (T0, 0),
+    (T1, 1),
+    (T2, 2),
+    (T3, 3),
+    (T4, 4),
+    (T5, 5),
+}
+implement_tuple! {
+    7,
+    (T0, 0),
+    (T1, 1),
+    (T2, 2),
+    (T3, 3),
+    (T4, 4),
+    (T5, 5),
+    (T6, 6),
+}
+implement_tuple! {
+    8,
+    (T0, 0),
+    (T1, 1),
+    (T2, 2),
+    (T3, 3),
+    (T4, 4),
+    (T5, 5),
+    (T6, 6),
+    (T7, 7),
+}
+implement_tuple! {
+    9,
+    (T0, 0),
+    (T1, 1),
+    (T2, 2),
+    (T3, 3),
+    (T4, 4),
+    (T5, 5),
+    (T6, 6),
+    (T7, 7),
+    (T8, 8),
+}
+implement_tuple! {
+    10,
+    (T0, 0),
+    (T1, 1),
+    (T2, 2),
+    (T3, 3),
+    (T4, 4),
+    (T5, 5),
+    (T6, 6),
+    (T7, 7),
+    (T8, 8),
+    (T9, 9),
+}
+implement_tuple! {
+    11,
+    (T0, 0),
+    (T1, 1),
+    (T2, 2),
+    (T3, 3),
+    (T4, 4),
+    (T5, 5),
+    (T6, 6),
+    (T7, 7),
+    (T8, 8),
+    (T9, 9),
+    (T10, 10),
+}
+implement_tuple! {
+    12,
+    (T0, 0),
+    (T1, 1),
+    (T2, 2),
+    (T3, 3),
+    (T4, 4),
+    (T5, 5),
+    (T6, 6),
+    (T7, 7),
+    (T8, 8),
+    (T9, 9),
+    (T10, 10),
+    (T11, 11),
+}

--- a/gel-protocol/tests/decode.rs
+++ b/gel-protocol/tests/decode.rs
@@ -3,6 +3,11 @@ use gel_protocol::queryable::Queryable;
 
 #[test]
 fn decode_vector() {
-    let vec = Vector::decode(&Default::default(), b"\0\x03\0\0?\x80\0\0@\0\0\0@@\0\0").unwrap();
+    let vec = Vector::decode(
+        &Default::default(),
+        &(),
+        b"\0\x03\0\0?\x80\0\0@\0\0\0@@\0\0",
+    )
+    .unwrap();
     assert_eq!(vec, Vector(vec![1., 2., 3.]));
 }


### PR DESCRIPTION
This is needed for runtime state of decoding *each* object separately. 

We already have `Decoder` that holds similar information, but it constructed for the whole data structure that is being decoded. These args are meant for each node separately and can even differ in type. 