### PR TITLE
Order shape elements before decoding

### DIFF
--- a/gel-derive/tests/json.rs
+++ b/gel-derive/tests/json.rs
@@ -34,7 +34,8 @@ fn json_field() {
         \0\0\x0b\x86\0\0\0\x10\xf2\xe6F9\xd7\x04\x11\xea\
         \xa0<\x83\x9f\xd9\xbd\x88\x94\0\0\0\x19\
         \0\0\0\x02id\0\0\x0e\xda\0\0\0\x10\x01{\"field1\": 123}";
-    let res = ShapeWithJson::decode(&old_decoder(), &(), data);
+    let order = vec![0, 1];
+    let res = ShapeWithJson::decode(&old_decoder(), &order, data);
     assert_eq!(
         res.unwrap(),
         ShapeWithJson {

--- a/gel-derive/tests/json.rs
+++ b/gel-derive/tests/json.rs
@@ -34,7 +34,7 @@ fn json_field() {
         \0\0\x0b\x86\0\0\0\x10\xf2\xe6F9\xd7\x04\x11\xea\
         \xa0<\x83\x9f\xd9\xbd\x88\x94\0\0\0\x19\
         \0\0\0\x02id\0\0\x0e\xda\0\0\0\x10\x01{\"field1\": 123}";
-    let order = vec![0, 1];
+    let order = (vec![0_usize, 1], ((), ()));
     let res = ShapeWithJson::decode(&old_decoder(), &order, data);
     assert_eq!(
         res.unwrap(),

--- a/gel-derive/tests/list_scalar_types.rs
+++ b/gel-derive/tests/list_scalar_types.rs
@@ -20,7 +20,8 @@ fn decode_new() {
     let data = b"\0\0\0\x03\0\0\0\x19\0\0\0\x0fcal::local_date\
                \0\0\0\x19\0\0\0 std::anyscalar, std::anydiscrete\
                \0\0\0\x19\0\0\0\x06normal";
-    let res = ScalarType::decode(&Decoder::default(), &(), data);
+    let order = vec![0, 1, 2];
+    let res = ScalarType::decode(&Decoder::default(), &order, data);
     assert_eq!(
         res.unwrap(),
         ScalarType {
@@ -38,7 +39,8 @@ fn decode_old() {
         \xee\xfc\xb6\x12\0\0\x0b\x86\0\0\0\x10\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
         \x01\x0c\0\0\0\x19\0\0\0\x0fcal::local_date\
         \0\0\0\x19\0\0\0\x0estd::anyscalar\0\0\0\x19\0\0\0\x06normal";
-    let res = ScalarType::decode(&old_decoder(), &(), data);
+    let order = vec![0, 1, 2];
+    let res = ScalarType::decode(&old_decoder(), &order, data);
     assert_eq!(
         res.unwrap(),
         ScalarType {

--- a/gel-derive/tests/list_scalar_types.rs
+++ b/gel-derive/tests/list_scalar_types.rs
@@ -20,7 +20,7 @@ fn decode_new() {
     let data = b"\0\0\0\x03\0\0\0\x19\0\0\0\x0fcal::local_date\
                \0\0\0\x19\0\0\0 std::anyscalar, std::anydiscrete\
                \0\0\0\x19\0\0\0\x06normal";
-    let order = vec![0, 1, 2];
+    let order = (vec![0, 1, 2], ((), (), ()));
     let res = ScalarType::decode(&Decoder::default(), &order, data);
     assert_eq!(
         res.unwrap(),
@@ -39,7 +39,7 @@ fn decode_old() {
         \xee\xfc\xb6\x12\0\0\x0b\x86\0\0\0\x10\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
         \x01\x0c\0\0\0\x19\0\0\0\x0fcal::local_date\
         \0\0\0\x19\0\0\0\x0estd::anyscalar\0\0\0\x19\0\0\0\x06normal";
-    let order = vec![0, 1, 2];
+    let order = (vec![0, 1, 2], ((), (), ()));
     let res = ScalarType::decode(&old_decoder(), &order, data);
     assert_eq!(
         res.unwrap(),

--- a/gel-derive/tests/varnames.rs
+++ b/gel-derive/tests/varnames.rs
@@ -14,7 +14,7 @@ fn decode() {
     let data = b"\0\0\0\x04\0\0\0\x14\0\0\0\x08\0\0\0\0\0\0\x03\0\0\0\
                   \0\x19\0\0\0\0\0\0\0\x19\0\0\0\x0bSomeDecoder\
                   \0\0\0\x14\0\0\0\x08\0\0\0\0\0\0\0{";
-    let order = vec![0, 1, 2, 3];
+    let order = (vec![0, 1, 2, 3], ((), (), (), ()));
     let res = WeirdStruct::decode(&Decoder::default(), &order, data);
     assert_eq!(
         res.unwrap(),

--- a/gel-derive/tests/varnames.rs
+++ b/gel-derive/tests/varnames.rs
@@ -14,7 +14,8 @@ fn decode() {
     let data = b"\0\0\0\x04\0\0\0\x14\0\0\0\x08\0\0\0\0\0\0\x03\0\0\0\
                   \0\x19\0\0\0\0\0\0\0\x19\0\0\0\x0bSomeDecoder\
                   \0\0\0\x14\0\0\0\x08\0\0\0\0\0\0\0{";
-    let res = WeirdStruct::decode(&Decoder::default(), &(), data);
+    let order = vec![0, 1, 2, 3];
+    let res = WeirdStruct::decode(&Decoder::default(), &order, data);
     assert_eq!(
         res.unwrap(),
         WeirdStruct {

--- a/gel-protocol/src/serialization/decode/raw_composite.rs
+++ b/gel-protocol/src/serialization/decode/raw_composite.rs
@@ -30,8 +30,16 @@ impl<'t> DecodeTupleLike<'t> {
         Ok(elements)
     }
 
-    pub fn read(&mut self) -> Result<Option<&[u8]>, DecodeError> {
+    pub fn read(&mut self) -> Result<Option<&'t [u8]>, DecodeError> {
         self.inner.read_object_element()
+    }
+
+    pub fn read_n(&mut self, n: usize) -> Result<Vec<Option<&'t [u8]>>, DecodeError> {
+        let mut bufs = Vec::with_capacity(n);
+        for _ in 0..n {
+            bufs.push(self.read()?);
+        }
+        Ok(bufs)
     }
 
     pub fn skip_element(&mut self) -> Result<(), DecodeError> {

--- a/gel-tokio/Cargo.toml
+++ b/gel-tokio/Cargo.toml
@@ -62,6 +62,7 @@ miette = { version = "7.2.0", features = ["fancy"] }
 gel-errors = { path = "../gel-errors", features = ["miette"] }
 test-utils = { git = "https://github.com/edgedb/test-utils.git" }
 tempfile = "3.13.0"
+tokio = { version = "1.15", features = ["rt"] }
 
 [features]
 default = ["derive", "env"]

--- a/gel-tokio/tests/func/client.rs
+++ b/gel-tokio/tests/func/client.rs
@@ -292,10 +292,7 @@ async fn wrong_field_number() -> anyhow::Result<()> {
         .query_required_single::<Thing, _>("select { a := 'hello', c := 'world' }", &())
         .await
         .unwrap_err();
-    assert_eq!(
-        format!("{err:#}"),
-        "DescriptorMismatch: unexpected field c, expected b"
-    );
+    assert_eq!(format!("{err:#}"), "DescriptorMismatch: expected field b");
 
     Ok(())
 }
@@ -353,6 +350,33 @@ async fn vector() -> anyhow::Result<()> {
         .await
         .unwrap();
     assert_eq!(res, 9.9);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn props_in_wrong_order() -> anyhow::Result<()> {
+    let client = Client::new(&SERVER.config);
+    client.ensure_connected().await?;
+
+    #[derive(Debug, PartialEq, Queryable)]
+    struct Foo {
+        foo: String,
+        bar: i64,
+    }
+
+    let res = client
+        .query_required_single::<Foo, _>("select { bar := 42, foo := 'hello' }", &())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        res,
+        Foo {
+            foo: "hello".into(),
+            bar: 42
+        }
+    );
 
     Ok(())
 }

--- a/gel-tokio/tests/func/client.rs
+++ b/gel-tokio/tests/func/client.rs
@@ -361,20 +361,45 @@ async fn props_in_wrong_order() -> anyhow::Result<()> {
 
     #[derive(Debug, PartialEq, Queryable)]
     struct Foo {
-        foo: String,
-        bar: i64,
+        hello: String,
+        world: i64,
     }
 
     let res = client
-        .query_required_single::<Foo, _>("select { bar := 42, foo := 'hello' }", &())
+        .query_required_single::<Foo, _>("select { world := 42, hello := 'hello' }", &())
         .await
         .unwrap();
 
     assert_eq!(
         res,
         Foo {
-            foo: "hello".into(),
-            bar: 42
+            hello: "hello".into(),
+            world: 42
+        }
+    );
+
+    #[derive(Debug, PartialEq, Queryable)]
+    struct Bar {
+        foo: Foo,
+        baz: i64,
+    }
+
+    let res = client
+        .query_required_single::<Bar, _>(
+            "select { baz := 3, foo := { world := 42, hello := 'hello' } }",
+            &(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        res,
+        Bar {
+            foo: Foo {
+                hello: "hello".into(),
+                world: 42
+            },
+            baz: 3
         }
     );
 


### PR DESCRIPTION
Make it so `Queryable` on structs does not require the struct to have the same order of fields as the shape elements in the EdgeQL query.

This is done by capturing the order of the shape elements in `check_descriptor` and then applying that order in `decode`.