### PR TITLE
Publish w/o nix

### DIFF
--- a/.github/workflows/publish-edgedb-auth.yaml
+++ b/.github/workflows/publish-edgedb-auth.yaml
@@ -13,25 +13,30 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      # checkout and env setup
-      - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/flakehub-cache-action@main
-      - name: Build the nix shell
-        run: nix develop --command just --version
+      - name: checkout and env setup
+        uses: actions/checkout@v3
 
-      # test
-      - name: Test
-        run: nix develop --command just test
+      - name: Extract project name and version
+        run: |
+          set -x
+          PROJECT_NAME=$(echo $GITHUB_REF | sed -E 's|refs/tags/releases/([^/]+)/v.*|\1|')
+          VERSION=$(echo $GITHUB_REF | sed -E 's|.*/v(.*)|\1|')
+          echo "PROJECT_NAME=$PROJECT_NAME" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       # verify that git tag matches cargo version
       - run: |
           set -x
           cargo_version="$(cargo metadata --format-version 1 \
-            | jq -r '.packages[] | select(.name=="gel-auth") | .version')"
-          tag_version="${GITHUB_REF#refs/tags/releases/gel-auth/v}"
-          test "$cargo_version" = "$tag_version"
+            | jq -r '.packages[] | select(.name==$PROJECT_NAME) | .version')"
+          test "$cargo_version" = "$VERSION"
 
-      - working-directory: ./gel-auth
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - working-directory: ./${{ env.PROJECT_NAME }}
         run: |
-          nix develop --command cargo publish --token=${{ secrets.CARGO_REGISTRY_TOKEN }}
+          cargo publish --token=${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-edgedb-derive.yaml
+++ b/.github/workflows/publish-edgedb-derive.yaml
@@ -13,25 +13,30 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      # checkout and env setup
-      - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/flakehub-cache-action@main
-      - name: Build the nix shell
-        run: nix develop --command just --version
+      - name: checkout and env setup
+        uses: actions/checkout@v3
 
-      # test
-      - name: Test
-        run: nix develop --command just test
+      - name: Extract project name and version
+        run: |
+          set -x
+          PROJECT_NAME=$(echo $GITHUB_REF | sed -E 's|refs/tags/releases/([^/]+)/v.*|\1|')
+          VERSION=$(echo $GITHUB_REF | sed -E 's|.*/v(.*)|\1|')
+          echo "PROJECT_NAME=$PROJECT_NAME" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       # verify that git tag matches cargo version
       - run: |
           set -x
           cargo_version="$(cargo metadata --format-version 1 \
-            | jq -r '.packages[] | select(.name=="gel-derive") | .version')"
-          tag_version="${GITHUB_REF#refs/tags/releases/gel-derive/v}"
-          test "$cargo_version" = "$tag_version"
+            | jq -r '.packages[] | select(.name==$PROJECT_NAME) | .version')"
+          test "$cargo_version" = "$VERSION"
 
-      - working-directory: ./gel-derive
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - working-directory: ./${{ env.PROJECT_NAME }}
         run: |
-          nix develop --command cargo publish --token=${{ secrets.CARGO_REGISTRY_TOKEN }}
+          cargo publish --token=${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-edgedb-errors.yaml
+++ b/.github/workflows/publish-edgedb-errors.yaml
@@ -13,25 +13,30 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      # checkout and env setup
-      - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/flakehub-cache-action@main
-      - name: Build the nix shell
-        run: nix develop --command cargo --version
+      - name: checkout and env setup
+        uses: actions/checkout@v3
 
-      # test
-      - name: Test
-        run: nix develop --command just test
+      - name: Extract project name and version
+        run: |
+          set -x
+          PROJECT_NAME=$(echo $GITHUB_REF | sed -E 's|refs/tags/releases/([^/]+)/v.*|\1|')
+          VERSION=$(echo $GITHUB_REF | sed -E 's|.*/v(.*)|\1|')
+          echo "PROJECT_NAME=$PROJECT_NAME" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       # verify that git tag matches cargo version
       - run: |
           set -x
           cargo_version="$(cargo metadata --format-version 1 \
-            | jq -r '.packages[] | select(.name=="gel-errors") | .version')"
-          tag_version="${GITHUB_REF#refs/tags/releases/gel-errors/v}"
-          test "$cargo_version" = "$tag_version"
+            | jq -r '.packages[] | select(.name==$PROJECT_NAME) | .version')"
+          test "$cargo_version" = "$VERSION"
 
-      - working-directory: ./gel-errors
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - working-directory: ./${{ env.PROJECT_NAME }}
         run: |
-          nix develop --command cargo publish --token=${{ secrets.CARGO_REGISTRY_TOKEN }}
+          cargo publish --token=${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-edgedb-protocol.yaml
+++ b/.github/workflows/publish-edgedb-protocol.yaml
@@ -13,25 +13,30 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      # checkout and env setup
-      - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/flakehub-cache-action@main
-      - name: Build the nix shell
-        run: nix develop --command just --version
+      - name: checkout and env setup
+        uses: actions/checkout@v3
 
-      # test
-      - name: Test
-        run: nix develop --command just test
+      - name: Extract project name and version
+        run: |
+          set -x
+          PROJECT_NAME=$(echo $GITHUB_REF | sed -E 's|refs/tags/releases/([^/]+)/v.*|\1|')
+          VERSION=$(echo $GITHUB_REF | sed -E 's|.*/v(.*)|\1|')
+          echo "PROJECT_NAME=$PROJECT_NAME" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       # verify that git tag matches cargo version
       - run: |
           set -x
           cargo_version="$(cargo metadata --format-version 1 \
-            | jq -r '.packages[] | select(.name=="gel-protocol") | .version')"
-          tag_version="${GITHUB_REF#refs/tags/releases/gel-protocol/v}"
-          test "$cargo_version" = "$tag_version"
+            | jq -r '.packages[] | select(.name==$PROJECT_NAME) | .version')"
+          test "$cargo_version" = "$VERSION"
 
-      - working-directory: ./gel-protocol
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - working-directory: ./${{ env.PROJECT_NAME }}
         run: |
-          nix develop --command cargo publish --token=${{ secrets.CARGO_REGISTRY_TOKEN }}
+          cargo publish --token=${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-edgedb-stream.yaml
+++ b/.github/workflows/publish-edgedb-stream.yaml
@@ -13,25 +13,30 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      # checkout and env setup
-      - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/flakehub-cache-action@main
-      - name: Build the nix shell
-        run: nix develop --command just --version
+      - name: checkout and env setup
+        uses: actions/checkout@v3
 
-      # test
-      - name: Test
-        run: nix develop --command just test
+      - name: Extract project name and version
+        run: |
+          set -x
+          PROJECT_NAME=$(echo $GITHUB_REF | sed -E 's|refs/tags/releases/([^/]+)/v.*|\1|')
+          VERSION=$(echo $GITHUB_REF | sed -E 's|.*/v(.*)|\1|')
+          echo "PROJECT_NAME=$PROJECT_NAME" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       # verify that git tag matches cargo version
       - run: |
           set -x
           cargo_version="$(cargo metadata --format-version 1 \
-            | jq -r '.packages[] | select(.name=="gel-stream") | .version')"
-          tag_version="${GITHUB_REF#refs/tags/releases/gel-stream/v}"
-          test "$cargo_version" = "$tag_version"
+            | jq -r '.packages[] | select(.name==$PROJECT_NAME) | .version')"
+          test "$cargo_version" = "$VERSION"
 
-      - working-directory: ./gel-stream
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - working-directory: ./${{ env.PROJECT_NAME }}
         run: |
-          nix develop --command cargo publish --token=${{ secrets.CARGO_REGISTRY_TOKEN }}
+          cargo publish --token=${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-edgedb-tokio.yaml
+++ b/.github/workflows/publish-edgedb-tokio.yaml
@@ -13,26 +13,30 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      # checkout and env setup
-      - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/flakehub-cache-action@main
-      - name: Build the nix shell
-        run: nix build '.#devShells.x86_64-linux.default'
+      - name: checkout and env setup
+        uses: actions/checkout@v3
 
-      # test
-      - name: Test
-        run: nix develop --command just test
+      - name: Extract project name and version
+        run: |
+          set -x
+          PROJECT_NAME=$(echo $GITHUB_REF | sed -E 's|refs/tags/releases/([^/]+)/v.*|\1|')
+          VERSION=$(echo $GITHUB_REF | sed -E 's|.*/v(.*)|\1|')
+          echo "PROJECT_NAME=$PROJECT_NAME" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       # verify that git tag matches cargo version
       - run: |
           set -x
           cargo_version="$(cargo metadata --format-version 1 \
-            | jq -r '.packages[] | select(.name=="gel-tokio") | .version')"
-          tag_version="${GITHUB_REF#refs/tags/releases/gel-tokio/v}"
-          test "$cargo_version" = "$tag_version"
+            | jq -r '.packages[] | select(.name==$PROJECT_NAME) | .version')"
+          test "$cargo_version" = "$VERSION"
 
-      # publish
-      - working-directory: ./gel-tokio
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - working-directory: ./${{ env.PROJECT_NAME }}
         run: |
-          nix develop --command cargo publish --token=${{ secrets.CARGO_REGISTRY_TOKEN }}
+          cargo publish --token=${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
The nix caching services are no longer easy to access and publishes are taking ~20 mins. This swaps out the nix publishing process for a standard Rust publishing process.

Each script now uses a standard body so we can more easily update the body of the publishing script. The tag name determines the project name environment variable.
