### PR TITLE
Use gel-auth for gel-tokio authentication state machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ docs can currently be found on docs.rs:
 Running Tests
 =============
 
-See [justfile](./justfile) for all commands to run the complete test suite.
+`cargo test --all-features` will test most features of the creates in this
+repository, however some feature combinations will not be tested. See
+[justfile](./justfile) for all commands to run the complete feature matrix test
+suite.
 
 License
 =======
-
 
 Licensed under either of
 

--- a/gel-auth/src/handshake/client_auth.rs
+++ b/gel-auth/src/handshake/client_auth.rs
@@ -1,0 +1,222 @@
+use crate::{
+    md5::md5_password,
+    scram::{
+        generate_nonce, generate_salted_password, ClientEnvironment, ClientTransaction, SCRAMError,
+        Sha256Out,
+    },
+    AuthType, CredentialData,
+};
+use tracing::error;
+
+#[derive(Debug)]
+pub enum ClientAuthResponse {
+    Initial(AuthType, Vec<u8>),
+    Continue(Vec<u8>),
+    Complete,
+    Waiting,
+    Error(ClientAuthError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ClientAuthError {
+    #[error("SCRAM protocol error: {0}")]
+    ScramError(#[from] SCRAMError),
+    #[error("Invalid authentication state")]
+    InvalidState,
+    #[error("Invalid credentials")]
+    InvalidCredentials,
+    #[error("Unexpected message during authentication")]
+    UnexpectedMessage,
+}
+
+#[derive(Debug)]
+enum ClientAuthState {
+    Initial(String, CredentialData),
+    Complete,
+    Waiting,
+    Sasl(ClientTransaction, ClientEnvironmentImpl),
+}
+
+#[derive(Debug)]
+pub enum ClientAuthDrive<'a> {
+    /// Authentication is successful.
+    Ok,
+    /// Server requested plain authentication.
+    Plain,
+    /// Server requested MD5 authentication (with salt).
+    Md5([u8; 4]),
+    /// Server requested SCRAM authentication.
+    Scram,
+    /// Server sent SCRAM message.
+    ScramResponse(&'a [u8]),
+}
+
+#[derive(Debug)]
+pub struct ClientAuth {
+    state: ClientAuthState,
+    auth_type: Option<AuthType>,
+}
+
+impl ClientAuth {
+    /// Create a new client authentication state.
+    pub fn new(username: String, credentials: CredentialData) -> Self {
+        Self {
+            state: ClientAuthState::Initial(username, credentials),
+            auth_type: None,
+        }
+    }
+
+    pub fn is_complete(&self) -> bool {
+        matches!(self.state, ClientAuthState::Complete)
+    }
+
+    pub fn auth_type(&self) -> Option<AuthType> {
+        self.auth_type
+    }
+
+    pub fn drive(&mut self, drive: ClientAuthDrive) -> Result<ClientAuthResponse, ClientAuthError> {
+        match (&mut self.state, drive) {
+            (ClientAuthState::Initial(username, credentials), drive) => {
+                let username = std::mem::take(username);
+                let credentials = std::mem::replace(credentials, CredentialData::Deny);
+                self.handle_initial(username, credentials, drive)
+            }
+            // SCRAM authentication: Handle SCRAM protocol messages.
+            (ClientAuthState::Sasl(tx, env), ClientAuthDrive::ScramResponse(message)) => {
+                let response = tx.process_message(&message, env)?;
+                match response {
+                    Some(response) => Ok(ClientAuthResponse::Continue(response)),
+                    None => {
+                        self.state = ClientAuthState::Waiting;
+                        Ok(ClientAuthResponse::Waiting)
+                    }
+                }
+            }
+            (ClientAuthState::Sasl(..), _) => Err(ClientAuthError::InvalidState),
+
+            // Handle "Ok" drive (authentication successful).
+            (_, ClientAuthDrive::Ok) => {
+                self.state = ClientAuthState::Complete;
+                Ok(ClientAuthResponse::Complete)
+            }
+
+            // Invalid state/drive combination.
+            (_, drive) => {
+                error!("Received invalid drive {drive:?} in state {:?}", self.state);
+                Err(ClientAuthError::InvalidState)
+            }
+        }
+    }
+
+    fn handle_initial(
+        &mut self,
+        username: String,
+        credentials: CredentialData,
+        drive: ClientAuthDrive,
+    ) -> Result<ClientAuthResponse, ClientAuthError> {
+        let (auth_type, (state, response)) = match drive {
+            ClientAuthDrive::Ok => (
+                AuthType::Trust,
+                match credentials {
+                    CredentialData::Deny => (
+                        ClientAuthState::Complete,
+                        ClientAuthResponse::Error(ClientAuthError::InvalidCredentials),
+                    ),
+                    _ => (ClientAuthState::Complete, ClientAuthResponse::Complete),
+                },
+            ),
+            ClientAuthDrive::Plain => (
+                AuthType::Plain,
+                match credentials {
+                    CredentialData::Plain(credentials) => (
+                        ClientAuthState::Waiting,
+                        ClientAuthResponse::Initial(
+                            AuthType::Plain,
+                            credentials.clone().into_bytes(),
+                        ),
+                    ),
+                    _ => (
+                        ClientAuthState::Complete,
+                        ClientAuthResponse::Error(ClientAuthError::InvalidCredentials),
+                    ),
+                },
+            ),
+            ClientAuthDrive::Md5(salt) => (
+                AuthType::Md5,
+                match credentials {
+                    CredentialData::Md5(credentials) => (
+                        ClientAuthState::Waiting,
+                        ClientAuthResponse::Initial(
+                            AuthType::Md5,
+                            credentials.salted(salt).into_bytes(),
+                        ),
+                    ),
+                    CredentialData::Plain(credentials) => (
+                        ClientAuthState::Waiting,
+                        ClientAuthResponse::Initial(
+                            AuthType::Md5,
+                            md5_password(&credentials, &username, salt).into_bytes(),
+                        ),
+                    ),
+                    _ => (
+                        ClientAuthState::Complete,
+                        ClientAuthResponse::Error(ClientAuthError::InvalidCredentials),
+                    ),
+                },
+            ),
+            ClientAuthDrive::Scram => (
+                AuthType::ScramSha256,
+                match credentials {
+                    CredentialData::Plain(credentials) => {
+                        let env = ClientEnvironmentImpl {
+                            password: credentials,
+                        };
+                        let mut tx = ClientTransaction::new(username.into());
+                        let response = tx.process_message(&[], &env);
+                        match response {
+                            Ok(Some(response)) => (
+                                ClientAuthState::Sasl(tx, env),
+                                ClientAuthResponse::Initial(AuthType::ScramSha256, response),
+                            ),
+                            Ok(None) => (
+                                ClientAuthState::Complete,
+                                ClientAuthResponse::Error(ClientAuthError::InvalidCredentials),
+                            ),
+                            Err(e) => (
+                                ClientAuthState::Complete,
+                                ClientAuthResponse::Error(ClientAuthError::ScramError(e)),
+                            ),
+                        }
+                    }
+                    _ => (
+                        ClientAuthState::Complete,
+                        ClientAuthResponse::Error(ClientAuthError::InvalidCredentials),
+                    ),
+                },
+            ),
+            _ => {
+                error!("Received invalid drive {drive:?} in state Initial");
+                return Err(ClientAuthError::InvalidState);
+            }
+        };
+
+        self.auth_type = Some(auth_type);
+        self.state = state;
+        Ok(response)
+    }
+}
+
+#[derive(Debug)]
+struct ClientEnvironmentImpl {
+    password: String,
+}
+
+impl ClientEnvironment for ClientEnvironmentImpl {
+    fn generate_nonce(&self) -> String {
+        generate_nonce()
+    }
+
+    fn get_salted_password(&self, salt: &[u8], iterations: usize) -> Sha256Out {
+        generate_salted_password(self.password.as_bytes(), salt, iterations)
+    }
+}

--- a/gel-auth/src/handshake/mod.rs
+++ b/gel-auth/src/handshake/mod.rs
@@ -1,5 +1,171 @@
 //! Handshake state machines for client/server authentication.
 
+mod client_auth;
 mod server_auth;
 
+pub use client_auth::*;
 pub use server_auth::*;
+
+#[cfg(test)]
+mod tests {
+    use crate::{AuthType, CredentialData};
+
+    use super::*;
+
+    const USERNAME: &str = "username";
+    const PASSWORD: &str = "password";
+
+    #[test]
+    fn test_client_server_trust() {
+        let mut server = ServerAuth::new(USERNAME.into(), AuthType::Trust, CredentialData::Trust);
+        let mut client = ClientAuth::new(USERNAME.into(), CredentialData::Trust);
+
+        let ServerAuthResponse::Complete(message) = server.drive(ServerAuthDrive::Initial) else {
+            panic!("Server auth should complete");
+        };
+
+        assert!(message.is_empty());
+
+        let Ok(ClientAuthResponse::Complete) = client.drive(ClientAuthDrive::Ok) else {
+            panic!("Client auth should complete");
+        };
+
+        assert!(server.is_complete());
+        assert!(client.is_complete());
+    }
+
+    #[test]
+    fn test_client_server_plain() {
+        let mut server = ServerAuth::new(
+            USERNAME.into(),
+            AuthType::Plain,
+            CredentialData::Plain(PASSWORD.into()),
+        );
+        let mut client = ClientAuth::new(USERNAME.into(), CredentialData::Plain(PASSWORD.into()));
+
+        let ServerAuthResponse::Initial(AuthType::Plain, message) =
+            server.drive(ServerAuthDrive::Initial)
+        else {
+            panic!("Server auth should ask for plain password");
+        };
+
+        assert!(message.is_empty());
+
+        let Ok(ClientAuthResponse::Initial(AuthType::Plain, message)) =
+            client.drive(ClientAuthDrive::Plain)
+        else {
+            panic!("Client auth should send plain password");
+        };
+
+        let ServerAuthResponse::Complete(message) =
+            server.drive(ServerAuthDrive::Message(AuthType::Plain, &message))
+        else {
+            panic!("Server auth should complete");
+        };
+
+        assert!(message.is_empty());
+
+        let Ok(ClientAuthResponse::Complete) = client.drive(ClientAuthDrive::Ok) else {
+            panic!("Client auth should complete");
+        };
+
+        assert!(server.is_complete());
+        assert!(client.is_complete());
+    }
+
+    #[test]
+    fn test_client_server_md5() {
+        let mut server = ServerAuth::new(
+            USERNAME.into(),
+            AuthType::Md5,
+            CredentialData::Plain(PASSWORD.into()),
+        );
+        let mut client = ClientAuth::new(USERNAME.into(), CredentialData::Plain(PASSWORD.into()));
+
+        let ServerAuthResponse::Initial(AuthType::Md5, salt) =
+            server.drive(ServerAuthDrive::Initial)
+        else {
+            panic!("Server auth should ask for MD5 password");
+        };
+
+        let salt_array: [u8; 4] = salt.try_into().unwrap();
+
+        let Ok(ClientAuthResponse::Initial(AuthType::Md5, message)) =
+            client.drive(ClientAuthDrive::Md5(salt_array))
+        else {
+            panic!("Client auth should send MD5 password");
+        };
+
+        let ServerAuthResponse::Complete(message) =
+            server.drive(ServerAuthDrive::Message(AuthType::Md5, &message))
+        else {
+            panic!("Server auth should complete");
+        };
+
+        assert!(message.is_empty());
+
+        let Ok(ClientAuthResponse::Complete) = client.drive(ClientAuthDrive::Ok) else {
+            panic!("Client auth should complete");
+        };
+
+        assert!(server.is_complete());
+        assert!(client.is_complete());
+    }
+
+    #[test]
+    fn test_client_server_scram() {
+        let mut server = ServerAuth::new(
+            USERNAME.into(),
+            AuthType::ScramSha256,
+            CredentialData::Plain(PASSWORD.into()),
+        );
+        let mut client = ClientAuth::new(USERNAME.into(), CredentialData::Plain(PASSWORD.into()));
+
+        let ServerAuthResponse::Initial(AuthType::ScramSha256, message) =
+            server.drive(ServerAuthDrive::Initial)
+        else {
+            panic!("Server auth should ask for SCRAM password");
+        };
+
+        assert!(message.is_empty());
+
+        let Ok(ClientAuthResponse::Initial(AuthType::ScramSha256, message)) =
+            client.drive(ClientAuthDrive::Scram)
+        else {
+            panic!("Client auth should send SCRAM password");
+        };
+
+        let ServerAuthResponse::Continue(message) =
+            server.drive(ServerAuthDrive::Message(AuthType::ScramSha256, &message))
+        else {
+            panic!("Server auth should continue");
+        };
+
+        let Ok(ClientAuthResponse::Continue(message)) =
+            client.drive(ClientAuthDrive::ScramResponse(&message))
+        else {
+            panic!("Client auth should continue");
+        };
+
+        let ServerAuthResponse::Complete(message) =
+            server.drive(ServerAuthDrive::Message(AuthType::ScramSha256, &message))
+        else {
+            panic!("Server auth should complete");
+        };
+
+        assert!(!message.is_empty());
+
+        let Ok(ClientAuthResponse::Waiting) =
+            client.drive(ClientAuthDrive::ScramResponse(&message))
+        else {
+            panic!("Client auth should wait");
+        };
+
+        let Ok(ClientAuthResponse::Complete) = client.drive(ClientAuthDrive::Ok) else {
+            panic!("Client auth should complete");
+        };
+
+        assert!(server.is_complete());
+        assert!(client.is_complete());
+    }
+}

--- a/gel-auth/src/md5.rs
+++ b/gel-auth/src/md5.rs
@@ -20,27 +20,11 @@
 /// let password = "secret";
 /// let username = "user";
 /// let salt = [0x01, 0x02, 0x03, 0x04];
-/// let hash = md5_password(password, username, &salt);
+/// let hash = md5_password(password, username, salt);
 /// assert_eq!(hash, "md5fccef98e4f1cf6cbe96b743fad4e8bd0");
 /// ```
-pub fn md5_password(password: &str, username: &str, salt: &[u8; 4]) -> String {
-    // First MD5 hash of password + username
-    let mut hasher = md5::Context::new();
-    hasher.consume(password.as_bytes());
-    hasher.consume(username.as_bytes());
-    let first_hash = hasher.compute();
-
-    // Convert first hash to hex string
-    let first_hash_hex = to_hex_string(&first_hash.0);
-
-    // Second MD5 hash of first hash + salt
-    let mut hasher = md5::Context::new();
-    hasher.consume(first_hash_hex.as_bytes());
-    hasher.consume(salt);
-    let second_hash = hasher.compute();
-
-    // Combine 'md5' prefix with final hash
-    format!("md5{}", to_hex_string(&second_hash.0))
+pub fn md5_password(password: &str, username: &str, salt: [u8; 4]) -> String {
+    StoredHash::generate(password.as_bytes(), username).salted(salt)
 }
 
 /// Converts a byte slice to a hexadecimal string.
@@ -69,6 +53,11 @@ impl StoredHash {
     }
 
     pub fn matches(&self, client_exchange: &[u8], salt: [u8; 4]) -> bool {
+        let server_exchange = self.salted(salt);
+        constant_time_eq::constant_time_eq(client_exchange, server_exchange.as_bytes())
+    }
+
+    pub fn salted(&self, salt: [u8; 4]) -> String {
         let this = &self;
         let salt: &[u8; 4] = &salt;
         // Convert first hash to hex string
@@ -83,8 +72,7 @@ impl StoredHash {
         // Convert second hash to hex string
         let second_hash_hex = to_hex_string(&second_hash.0);
 
-        let server_exchange = format!("md5{}", second_hash_hex);
-        constant_time_eq::constant_time_eq(client_exchange, server_exchange.as_bytes())
+        format!("md5{}", second_hash_hex)
     }
 }
 


### PR DESCRIPTION
Implement a new client state machine in `gel-auth` and use it for `gel-tokio`. The Gel protocol only supports TRUST or SCRAM-SHA-256, but we implement all of the various auth types so we can re-use this for `pgrust`.