### PR TITLE
Migrate gel-dsn fully to derive_more::Error

### DIFF
--- a/gel-dsn/Cargo.toml
+++ b/gel-dsn/Cargo.toml
@@ -25,7 +25,6 @@ unstable = []
 [dependencies]
 percent-encoding = "2"
 url = "2"
-thiserror = "2"
 derive_more = { version = "2", features = ["display", "error"] }
 serde = { version = "1", optional = true, features = ["derive"] }
 serde_json = "1"

--- a/gel-dsn/src/gel/config.rs
+++ b/gel-dsn/src/gel/config.rs
@@ -3,7 +3,7 @@ use super::{
     Param, Params,
 };
 use crate::{
-    gel::parse_duration,
+    gel::{parse_duration, BuildPhase},
     host::{Host, HostType, LOCALHOST_HOSTNAME},
 };
 use rustls_pki_types::CertificateDer;
@@ -136,9 +136,9 @@ impl Default for Config {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Eq, derive_more::Error, derive_more::Display)]
 pub enum CredentialsError {
-    #[error("no TCP address")]
+    #[display("no TCP address")]
     NoTcpAddress,
 }
 
@@ -842,10 +842,13 @@ impl TryInto<Params> for ConnectionOptions {
 
     fn try_into(self) -> Result<Params, Self::Error> {
         if self.credentials.is_some() && self.credentials_file.is_some() {
-            return Err(ParseError::MultipleCompoundOpts(vec![
-                CompoundSource::CredentialsFile,
-                CompoundSource::CredentialsFile,
-            ]));
+            return Err(ParseError::MultipleCompound(
+                BuildPhase::Options,
+                vec![
+                    CompoundSource::CredentialsFile,
+                    CompoundSource::CredentialsFile,
+                ],
+            ));
         }
 
         if self.tls_ca.is_some() && self.tls_ca_file.is_some() {

--- a/gel-dsn/src/gel/params.rs
+++ b/gel-dsn/src/gel/params.rs
@@ -27,10 +27,13 @@ use crate::{
     EnvVar, FileAccess, UserProfile,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum BuildPhase {
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, derive_more::Display)]
+pub enum BuildPhase {
+    #[display("command-line or driver options")]
     Options,
+    #[display("environment variables")]
     Environment,
+    #[display("project directory")]
     Project,
 }
 
@@ -751,11 +754,7 @@ impl Params {
         // Step 0: Check for compound option overlap. If there is, return an error.
         let compound_sources = self.check_overlap();
         if compound_sources.len() > 1 {
-            if phase == BuildPhase::Options {
-                return Err(ParseError::MultipleCompoundOpts(compound_sources));
-            } else {
-                return Err(ParseError::MultipleCompoundEnv(compound_sources));
-            }
+            return Err(ParseError::MultipleCompound(phase, compound_sources));
         }
 
         // Step 1: Resolve DSN, credentials file, instance if available

--- a/gel-dsn/src/postgres/mod.rs
+++ b/gel-dsn/src/postgres/mod.rs
@@ -6,7 +6,6 @@
 //!  - `database` is recognized as an alias for `dbname`
 //!  - `[host1,host2]` is considered valid for psql
 use gel_stream::SslVersionParseError;
-use thiserror::Error;
 
 mod host;
 mod params;
@@ -20,38 +19,41 @@ pub use passfile::{Password, PasswordWarning};
 pub use raw_params::{RawConnectionParameters, SslMode};
 pub use url::{parse_postgres_dsn, parse_postgres_dsn_env};
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, derive_more::Display, derive_more::From, derive_more::Error)]
 #[allow(clippy::enum_variant_names)]
+// #[error(not(source))] because derive_more infers a source for a single-field error
 pub enum ParseError {
-    #[error(
-        "Invalid DSN: scheme is expected to be either \"postgresql\" or \"postgres\", got {0}"
+    #[display(
+        "Invalid DSN: scheme is expected to be either \"postgresql\" or \"postgres\", got {_0}"
     )]
-    InvalidScheme(String),
+    InvalidScheme(#[error(not(source))] String),
 
-    #[error("Invalid value for parameter \"{0}\": \"{1}\"")]
+    #[display("Invalid value for parameter \"{_0}\": \"{_1}\"")]
     InvalidParameter(String, String),
 
-    #[error("Invalid percent encoding")]
+    #[display("Invalid percent encoding")]
     InvalidPercentEncoding,
 
-    #[error("Invalid port: \"{0}\"")]
-    InvalidPort(String),
+    #[display("Invalid port: \"{_0}\"")]
+    InvalidPort(#[error(not(source))] String),
 
-    #[error("Unexpected number of ports, must be either a single port or the same number as the host count: \"{0}\"")]
-    InvalidPortCount(String),
+    #[display("Unexpected number of ports, must be either a single port or the same number as the host count: \"{_0}\"")]
+    InvalidPortCount(#[error(not(source))] String),
 
-    #[error("Invalid hostname: \"{0}\"")]
-    InvalidHostname(String),
+    #[display("Invalid hostname: \"{_0}\"")]
+    InvalidHostname(#[error(not(source))] String),
 
-    #[error("Invalid query parameter: \"{0}\"")]
-    InvalidQueryParameter(String),
+    #[display("Invalid query parameter: \"{_0}\"")]
+    InvalidQueryParameter(#[error(not(source))] String),
 
-    #[error("Invalid TLS version: \"{0}\"")]
-    InvalidTLSVersion(#[from] SslVersionParseError),
+    #[display("Invalid TLS version: \"{_0}\"")]
+    #[from]
+    InvalidTLSVersion(SslVersionParseError),
 
-    #[error("Could not determine the connection {0}")]
-    MissingRequiredParameter(String),
+    #[display("Could not determine the connection {_0}")]
+    MissingRequiredParameter(#[error(not(source))] String),
 
-    #[error("URL parse error: {0}")]
-    UrlParseError(#[from] ::url::ParseError),
+    #[display("URL parse error: {_0}")]
+    #[from]
+    UrlParseError(::url::ParseError),
 }


### PR DESCRIPTION
Fully remove `thiserror` from `gel-dsn`. No functionality changes, just improving errors slightly.