### PR TITLE
Removing v0 protocol

### DIFF
--- a/gel-protocol/src/codec.rs
+++ b/gel-protocol/src/codec.rs
@@ -1384,10 +1384,13 @@ impl Codec for Array {
             _ => Err(errors::invalid_value(type_name::<Self>(), val))?,
         };
         if items.is_empty() {
-            buf.reserve(12);
-            buf.put_u32(0); // ndims
+            // Encoding with the short form causes errors in server < 7
+            buf.reserve(20);
+            buf.put_u32(1); // ndims
             buf.put_u32(0); // reserved0
             buf.put_u32(0); // reserved1
+            buf.put_u32(0);
+            buf.put_u32(1);
             return Ok(());
         }
         buf.reserve(20);

--- a/gel-protocol/src/features.rs
+++ b/gel-protocol/src/features.rs
@@ -20,9 +20,6 @@ impl ProtocolVersion {
     pub fn version_tuple(&self) -> (u16, u16) {
         (self.major_ver, self.minor_ver)
     }
-    pub fn is_1(&self) -> bool {
-        self.major_ver >= 1
-    }
     pub fn is_2(&self) -> bool {
         self.major_ver >= 2
     }
@@ -39,8 +36,8 @@ impl ProtocolVersion {
         // Some of pre 1.0 protocols required implicit id.
         // Later it was opt out. In 1.0 it's opt-in.
         // We never opt-in or opt-out so whether it's present only on pre 1.0
-        // portocols.
-        !self.is_1()
+        // protocols.
+        false
     }
     pub fn is_multilingual(&self) -> bool {
         self.is_at_least(3, 0)

--- a/gel-protocol/src/query_arg.rs
+++ b/gel-protocol/src/query_arg.rs
@@ -196,7 +196,11 @@ impl QueryArg for Value {
                     "named tuple object cannot be query argument",
                 ))
             }
-            Array(v) => v.encode_slot(enc)?,
+            Array(_) => {
+                return Err(ClientEncodingError::with_message(
+                    "array cannot be query argument",
+                ))
+            }
             Enum(v) => v.encode_slot(enc)?,
             Range(v) => v.encode_slot(enc)?,
             Vector(v) => crate::model::VectorRef(v).encode_slot(enc)?,

--- a/gel-protocol/tests/client_messages.rs
+++ b/gel-protocol/tests/client_messages.rs
@@ -5,14 +5,12 @@ use bytes::{Bytes, BytesMut};
 use gel_protocol::common::InputLanguage;
 use uuid::Uuid;
 
-use gel_protocol::client_message::OptimisticExecute;
+use gel_protocol::client_message::Execute1;
 use gel_protocol::client_message::Restore;
 use gel_protocol::client_message::SaslInitialResponse;
 use gel_protocol::client_message::SaslResponse;
-use gel_protocol::client_message::{Cardinality, IoFormat, Parse, Prepare};
+use gel_protocol::client_message::{Cardinality, IoFormat, Parse};
 use gel_protocol::client_message::{ClientHandshake, ClientMessage};
-use gel_protocol::client_message::{DescribeAspect, DescribeStatement};
-use gel_protocol::client_message::{Execute0, Execute1, ExecuteScript};
 use gel_protocol::common::{Capabilities, CompilationFlags, State};
 use gel_protocol::encoding::{Input, Output};
 use gel_protocol::features::ProtocolVersion;
@@ -52,35 +50,6 @@ fn client_handshake() -> Result<(), Box<dyn Error>> {
             extensions: HashMap::new(),
         }),
         b"\x56\x00\x00\x00\x0C\x00\x01\x00\x02\x00\x00\x00\x00"
-    );
-    Ok(())
-}
-
-#[test]
-fn execute_script() -> Result<(), Box<dyn Error>> {
-    encoding_eq!(
-        ClientMessage::ExecuteScript(ExecuteScript {
-            headers: HashMap::new(),
-            script_text: String::from("START TRANSACTION"),
-        }),
-        b"Q\0\0\0\x1b\0\0\0\0\0\x11START TRANSACTION"
-    );
-    Ok(())
-}
-
-#[test]
-fn prepare() -> Result<(), Box<dyn Error>> {
-    encoding_eq_ver!(
-        0,
-        13,
-        ClientMessage::Prepare(Prepare {
-            headers: HashMap::new(),
-            io_format: IoFormat::Binary,
-            expected_cardinality: Cardinality::AtMostOne,
-            statement_name: Bytes::from_static(b"example"),
-            command_text: String::from("SELECT 1;"),
-        }),
-        b"P\0\0\0 \0\0bo\0\0\0\x07example\0\0\0\tSELECT 1;"
     );
     Ok(())
 }
@@ -131,34 +100,6 @@ fn parse3() -> Result<(), Box<dyn Error>> {
         }),
         b"P\0\0\0B\0\0\0\0\0\0\0\0\0\x01\0\0\0\0\0\0\0\x02\0\0\0\0\0\0\0MEbo\
           \0\0\0\tSELECT 1;\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
-    );
-    Ok(())
-}
-
-#[test]
-fn describe_statement() -> Result<(), Box<dyn Error>> {
-    encoding_eq!(
-        ClientMessage::DescribeStatement(DescribeStatement {
-            headers: HashMap::new(),
-            aspect: DescribeAspect::DataDescription,
-            statement_name: Bytes::from_static(b"example"),
-        }),
-        b"D\0\0\0\x12\0\0T\0\0\0\x07example"
-    );
-    Ok(())
-}
-
-#[test]
-fn execute0() -> Result<(), Box<dyn Error>> {
-    encoding_eq_ver!(
-        0,
-        13,
-        ClientMessage::Execute0(Execute0 {
-            headers: HashMap::new(),
-            statement_name: Bytes::from_static(b"example"),
-            arguments: Bytes::new(),
-        }),
-        b"E\0\0\0\x15\0\0\0\0\0\x07example\0\0\0\0"
     );
     Ok(())
 }
@@ -224,35 +165,8 @@ fn execute3() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn optimistic_execute() -> Result<(), Box<dyn Error>> {
-    encoding_eq_ver!(
-        0,
-        13,
-        ClientMessage::OptimisticExecute(OptimisticExecute {
-            headers: HashMap::new(),
-            io_format: IoFormat::Binary,
-            expected_cardinality: Cardinality::AtMostOne,
-            command_text: String::from("COMMIT"),
-            input_typedesc_id: Uuid::from_u128(0xFF),
-            output_typedesc_id: Uuid::from_u128(0x0),
-            arguments: Bytes::new(),
-        }),
-        b"O\0\0\x006\0\0bo\0\0\0\x06COMMIT\
-               \0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\xff\
-               \0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
-    );
-    Ok(())
-}
-
-#[test]
 fn sync() -> Result<(), Box<dyn Error>> {
     encoding_eq!(ClientMessage::Sync, b"S\0\0\0\x04");
-    Ok(())
-}
-
-#[test]
-fn flush() -> Result<(), Box<dyn Error>> {
-    encoding_eq!(ClientMessage::Flush, b"H\0\0\0\x04");
     Ok(())
 }
 

--- a/gel-protocol/tests/codecs.rs
+++ b/gel-protocol/tests/codecs.rs
@@ -1001,9 +1001,10 @@ fn array() -> Result<(), Box<dyn Error>> {
             b"\0\0\0\x08\0\0\0\0\0\0\0\x03"),
         Value::Array(vec![Value::Int64(1), Value::Int64(2), Value::Int64(3),])
     );
+    // Encoded using the long-form of zero-sized arrays to work around server bug < 7.
     encoding_eq!(
         &codec,
-        bconcat!(b"\0\0\0\0\0\0\0\0\0\0\0\x00"),
+        bconcat!(b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01"),
         Value::Array(vec![])
     );
     Ok(())

--- a/gel-protocol/tests/server_messages.rs
+++ b/gel-protocol/tests/server_messages.rs
@@ -9,14 +9,14 @@ use gel_protocol::common::{Capabilities, RawTypedesc};
 use gel_protocol::encoding::{Input, Output};
 use gel_protocol::features::ProtocolVersion;
 use gel_protocol::server_message::Authentication;
+use gel_protocol::server_message::Cardinality;
+use gel_protocol::server_message::CommandComplete1;
 use gel_protocol::server_message::CommandDataDescription1;
+use gel_protocol::server_message::Data;
 use gel_protocol::server_message::RestoreReady;
 use gel_protocol::server_message::ServerHandshake;
 use gel_protocol::server_message::ServerMessage;
 use gel_protocol::server_message::StateDataDescription;
-use gel_protocol::server_message::{Cardinality, PrepareComplete};
-use gel_protocol::server_message::{CommandComplete0, CommandComplete1};
-use gel_protocol::server_message::{CommandDataDescription0, Data};
 use gel_protocol::server_message::{ErrorResponse, ErrorSeverity};
 use gel_protocol::server_message::{LogMessage, MessageSeverity};
 use gel_protocol::server_message::{ParameterStatus, ServerKeyData};
@@ -127,20 +127,6 @@ fn parameter_status() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn command_complete0() -> Result<(), Box<dyn Error>> {
-    encoding_eq_ver!(
-        0,
-        13,
-        ServerMessage::CommandComplete0(CommandComplete0 {
-            headers: HashMap::new(),
-            status_data: Bytes::from_static(b"okay"),
-        }),
-        b"C\0\0\0\x0e\0\0\0\0\0\x04okay"
-    );
-    Ok(())
-}
-
-#[test]
 fn command_complete1() -> Result<(), Box<dyn Error>> {
     encoding_eq_ver!(
         1,
@@ -154,82 +140,6 @@ fn command_complete1() -> Result<(), Box<dyn Error>> {
         b"C\0\0\0*\0\0\0\0\0\0\0\0\0\x01\0\0\0\x04okay\
           \0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
           \0\0\0\0"
-    );
-    Ok(())
-}
-
-#[test]
-fn prepare_complete() -> Result<(), Box<dyn Error>> {
-    encoding_eq!(
-        ServerMessage::PrepareComplete(PrepareComplete {
-            headers: HashMap::new(),
-            cardinality: Cardinality::AtMostOne,
-            input_typedesc_id: Uuid::from_u128(0xFF),
-            output_typedesc_id: Uuid::from_u128(0x105),
-        }),
-        b"1\0\0\0'\0\0o\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\xff\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01\x05"
-    );
-    encoding_eq!(
-        ServerMessage::PrepareComplete(PrepareComplete {
-            headers: HashMap::new(),
-            cardinality: Cardinality::NoResult,
-            input_typedesc_id: Uuid::from_u128(0xFF),
-            output_typedesc_id: Uuid::from_u128(0x0),
-        }),
-        b"1\0\0\0'\0\0n\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\xff\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
-    );
-    Ok(())
-}
-
-#[test]
-fn command_data_description0() -> Result<(), Box<dyn Error>> {
-    encoding_eq_ver!(
-        0,
-        13,
-        ServerMessage::CommandDataDescription0(CommandDataDescription0 {
-            headers: HashMap::new(),
-            result_cardinality: Cardinality::AtMostOne,
-            input: RawTypedesc {
-                proto: ProtocolVersion::new(0, 13),
-                id: Uuid::from_u128(0xFF),
-                data: Bytes::from_static(b"\x04\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\xff\0\0"),
-            },
-            output: RawTypedesc {
-                proto: ProtocolVersion::new(0, 13),
-                id: Uuid::from_u128(0x105),
-                data: Bytes::from_static(b"\x02\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01\x05"),
-            },
-        }),
-        bconcat!(b"T\0\0\0S\0\0o"
-                     b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\xff"
-                     b"\0\0\0\x13"
-                     b"\x04\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\xff\0"
-                     b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01\x05"
-                     b"\0\0\0\x11"
-                     b"\x02\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01\x05")
-    );
-    encoding_eq_ver!(
-        0,
-        13,
-        ServerMessage::CommandDataDescription0(CommandDataDescription0 {
-            headers: HashMap::new(),
-            result_cardinality: Cardinality::NoResult,
-            input: RawTypedesc {
-                proto: ProtocolVersion::new(0, 13),
-                id: Uuid::from_u128(0xFF),
-                data: Bytes::from_static(b"\x04\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\xff\0\0"),
-            },
-            output: RawTypedesc {
-                proto: ProtocolVersion::new(0, 13),
-                id: Uuid::from_u128(0),
-                data: Bytes::from_static(b""),
-            },
-        }),
-        bconcat!(b"T\0\0\0B\0\0n"
-                     b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\xff"
-                     b"\0\0\0\x13"
-                     b"\x04\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\xff\0"
-                     b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0")
     );
     Ok(())
 }


### PR DESCRIPTION
This removes all traces of v0 protocols from gel-tokio and gel-protocol. In addition, we work around an issue with empty array serialization for server versions < 7.